### PR TITLE
Refactor SettingsCard to use ButtonBase and fix SettingsExpander inner card structure

### DIFF
--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -3,17 +3,28 @@ import UWP
 import WinAppSDK
 import WinUI
 
-public class SettingsCard: Button {
+public class SettingsCard: ButtonBase {
     public var isClickEnabled = false
+
+    let cardBorder = WinUI.Border()
 
     private override init() {
         super.init()
+
+        let isDark = App.context.theme.isDark
 
         self.horizontalAlignment = .stretch
         self.verticalAlignment = .stretch
         self.horizontalContentAlignment = .stretch
         self.verticalContentAlignment = .stretch
-        self.padding = WinUI.Thickness(left: 10, top: 10, right: 10, bottom: 10)
+
+        cardBorder.background = cardBackgroundBrush(isDark: isDark)
+        cardBorder.borderBrush = cardBorderBrush(isDark: isDark)
+        cardBorder.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
+        cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
+        cardBorder.padding = WinUI.Thickness(left: 10, top: 10, right: 10, bottom: 10)
+
+        self.content = cardBorder
     }
 
     public convenience init(_ headerIconGlyph: String, _ header: String, _ description: String, _ content: FrameworkElement, _ actionIcon: FontIcon? = nil) {
@@ -21,7 +32,7 @@ public class SettingsCard: Button {
 
         let icon = WinUI.FontIcon()
         icon.glyph = headerIconGlyph
-        
+
         let textBlock: TextBlock = (try? XamlReader.load("""
             <TextBlock xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" >
             \(description)
@@ -32,7 +43,7 @@ public class SettingsCard: Button {
             return tb
         }()
 
-        self.content = build(
+        cardBorder.child = build(
             headerIcon: icon,
             header: header,
             description: textBlock,
@@ -53,7 +64,7 @@ public class SettingsCard: Button {
         let contentTextBlock = TextBlock()
         contentTextBlock.text = content
 
-        self.content = build(
+        cardBorder.child = build(
             headerIcon: icon,
             header: header,
             description: descTextBlock,
@@ -65,10 +76,18 @@ public class SettingsCard: Button {
     public convenience init(_ header: String, _ description: FrameworkElement) {
         self.init()
 
-        self.content = build(
+        cardBorder.child = build(
             header: header,
             description: description
         )
+    }
+
+    // Remove card border/background for use as an inner item inside SettingsExpander
+    func suppressCardStyling() {
+        cardBorder.background = nil
+        cardBorder.borderBrush = nil
+        cardBorder.borderThickness = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+        cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0)
     }
 
     private func build(headerIcon: IconElement? = nil, header: String, description: FrameworkElement, content: FrameworkElement? = nil, actionIcon: FontIcon? = nil) -> WinUI.Grid {

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -31,14 +31,24 @@ public class SettingsExpander: StackPanel {
         super.init()
 
         let isDark = App.context.theme.isDark
+
+        // Header card with card styling suppressed — outer card provides the border
         let card = SettingsCard(headerIconPath, header, description, content, chevron)
+        card.isClickEnabled = true
+        card.suppressCardStyling()
         card.click.addHandler { [weak self] _, _ in
             guard let self else { return }
             self.runExpandCollapseAnimation(expanding: !self.isExpanded)
         }
-        self.children.append(card)
 
         expandedHost.renderTransform = expandedTransform
+
+        // Divider between header and expanded items
+        let topDivider = WinUI.Border()
+        topDivider.height = 1
+        topDivider.margin = WinUI.Thickness(left: 16, top: 0, right: 16, bottom: 0)
+        topDivider.background = dividerBrush(isDark: isDark)
+        expandedHost.children.append(topDivider)
 
         for (index, item) in items.enumerated() {
             if index > 0 {
@@ -48,9 +58,25 @@ public class SettingsExpander: StackPanel {
                 divider.background = dividerBrush(isDark: isDark)
                 expandedHost.children.append(divider)
             }
+            item.suppressCardStyling()
             expandedHost.children.append(item)
         }
-        self.children.append(expandedHost)
+
+        // One outer card container wrapping both header and expanded items
+        let outerCard = WinUI.Border()
+        outerCard.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
+        outerCard.background = cardBackgroundBrush(isDark: isDark)
+        outerCard.borderBrush = cardBorderBrush(isDark: isDark)
+        outerCard.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
+
+        let cardStack = WinUI.StackPanel()
+        cardStack.orientation = .vertical
+        cardStack.spacing = 0
+        cardStack.children.append(card)
+        cardStack.children.append(expandedHost)
+
+        outerCard.child = cardStack
+        self.children.append(outerCard)
     }
 
     private func makeDuration(milliseconds: Int64) -> Duration {
@@ -354,7 +380,7 @@ private func dividerBrush(isDark: Bool) -> WinUI.SolidColorBrush {
     )
 }
 
-private func cardBackgroundBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+func cardBackgroundBrush(isDark: Bool) -> WinUI.SolidColorBrush {
     WinUI.SolidColorBrush(
         isDark
             ? UWP.Color(a: 255, r: 32, g: 36, b: 44)
@@ -362,7 +388,7 @@ private func cardBackgroundBrush(isDark: Bool) -> WinUI.SolidColorBrush {
     )
 }
 
-private func cardBorderBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+func cardBorderBrush(isDark: Bool) -> WinUI.SolidColorBrush {
     WinUI.SolidColorBrush(
         isDark
             ? UWP.Color(a: 255, r: 49, g: 55, b: 66)


### PR DESCRIPTION
将 SettingsCard 的基类从 Button 替换为 ButtonBase，消除了非可点击卡片上不必要的 hover/pressed 视觉状态
suppressCardStyling() 方法，用于在 SettingsExpander 内部使用卡片时去除卡片边框
重构 SettingsExpander，将 header 和展开内容统一包裹在一个外层卡片 Border 中，使展开内容在视觉上位于同一卡片边界内