### PR TITLE
feat: add splitter

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -138,9 +138,9 @@ class MainWindow: Window {
         nav.isPaneToggleButtonVisible = false
         nav.paneDisplayMode = .auto
         nav.compactModeThresholdWidth = 0
+        nav.expandedModeThresholdWidth = 0
         nav.isPaneOpen = viewModel.windowLayout.navigationViewPaneOpen
         nav.openPaneLength = Double(viewModel.windowLayout.navigationViewOpenPaneLength)
-        nav.expandedModeThresholdWidth = nav.openPaneLength + 688 // MARK: 600 is from defaults 1008 - 320
         nav.content = navigationContentFrame
 
         return nav
@@ -417,7 +417,6 @@ class MainWindow: Window {
 
     private func applyPaneLength(_ length: Double) {
         navigationView.openPaneLength = length
-        navigationView.expandedModeThresholdWidth = length + 688
         splitterBorder.margin = Thickness(
             left: length - splitterWidth / 2,
             top: 0, right: 0, bottom: 0

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -34,7 +34,7 @@ class MainWindow: Window {
     private var dragStartX: Double = 0
     private var dragStartPaneLength: Double = 0
     private let splitterWidth: Double = 6
-    private let minPaneLength: Double = 180
+    private let minPaneLength: Double = 48
     private let maxPaneLength: Double = 600
 
     /// UI 主要组件

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -28,6 +28,15 @@ class MainWindow: Window {
     private var viewModel: MainWindowViewModel! = MainWindowViewModel()
     private var isSyncingSelection = false
 
+    // Splitter state
+    private var splitterBorder: Border!
+    private var isDraggingSplitter = false
+    private var dragStartX: Double = 0
+    private var dragStartPaneLength: Double = 0
+    private let splitterWidth: Double = 6
+    private let minPaneLength: Double = 180
+    private let maxPaneLength: Double = 600
+
     /// UI 主要组件
     private static func makeNavButton(glyph: String, action: @escaping () -> Void) -> Button {
         let icon = FontIcon()
@@ -222,8 +231,23 @@ class MainWindow: Window {
                 _ = navigate(to: url)
             }
         }
-        root.children.append(navigationView)
-        try? Grid.setRow(navigationView, 1)
+
+        navigationView.paneClosed.addHandler { [weak self] _, _ in
+            self?.splitterBorder.visibility = .collapsed
+        }
+        navigationView.paneOpened.addHandler { [weak self] _, _ in
+            self?.splitterBorder.visibility = .visible
+        }
+
+        // Wrap NavigationView with splitter overlay
+        let navWrapper = Grid()
+        navWrapper.children.append(navigationView)
+        splitterBorder = makeSplitterBorder()
+        navWrapper.children.append(splitterBorder)
+        try? Canvas.setZIndex(splitterBorder, 10)
+
+        root.children.append(navWrapper)
+        try? Grid.setRow(navWrapper, 1)
 
         self.content = root
     }
@@ -336,5 +360,67 @@ class MainWindow: Window {
             viewModel.windowPosition.windowX = Int(hwnd.position.x)
             viewModel.windowPosition.windowY = Int(hwnd.position.y)
         }
+    }
+
+    // MARK: - Splitter Methods
+
+    private func makeSplitterBorder() -> Border {
+        let b = Border()
+        b.width = splitterWidth
+        b.verticalAlignment = .stretch
+        b.horizontalAlignment = .left
+        b.background = SolidColorBrush(UWP.Color(a: 0, r: 0, g: 0, b: 0)) // transparent hit area
+        b.margin = Thickness(
+            left: navigationView.openPaneLength - splitterWidth / 2,
+            top: 0, right: 0, bottom: 0
+        )
+        b.visibility = viewModel.windowLayout.navigationViewPaneOpen ? .visible : .collapsed
+        b.protectedCursor = try? InputSystemCursor.create(.sizeWestEast)
+
+        setupSplitterPointerEvents(b)
+        return b
+    }
+
+    private func setupSplitterPointerEvents(_ splitter: Border) {
+        splitter.pointerPressed.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            let point = try? args.getCurrentPoint(nil) // window-relative
+            self.isDraggingSplitter = true
+            self.dragStartX = Double(point?.position.x ?? 0)
+            self.dragStartPaneLength = self.navigationView.openPaneLength
+            _ = try? self.splitterBorder.capturePointer(args.pointer)
+            args.handled = true
+        }
+
+        splitter.pointerMoved.addHandler { [weak self] _, args in
+            guard let self, self.isDraggingSplitter, let args else { return }
+            let point = try? args.getCurrentPoint(nil) // window-relative
+            let currentX = Double(point?.position.x ?? 0)
+            let delta = currentX - self.dragStartX
+            let newLength = min(self.maxPaneLength, max(self.minPaneLength, self.dragStartPaneLength + delta))
+            self.applyPaneLength(newLength)
+            args.handled = true
+        }
+
+        splitter.pointerReleased.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            self.isDraggingSplitter = false
+            try? self.splitterBorder.releasePointerCapture(args.pointer)
+            args.handled = true
+        }
+
+        splitter.pointerCaptureLost.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            self.isDraggingSplitter = false
+        }
+    }
+
+    private func applyPaneLength(_ length: Double) {
+        navigationView.openPaneLength = length
+        navigationView.expandedModeThresholdWidth = length + 688
+        splitterBorder.margin = Thickness(
+            left: length - splitterWidth / 2,
+            top: 0, right: 0, bottom: 0
+        )
     }
 }


### PR DESCRIPTION
Need dragable navigation pane like Photos #33

## MicroSoft Photos

针对如上问题的提交，我在此先描述一下我观察到的Microsoft Photos(以下简称Photos)模式:
1. photo中的NavigationView切换状态(LeftCompact, Left)是通过左上角的按钮控制。
2. 在LeftCompact模式下只显示图标，且无法操纵splitter。
3. 在Left模式下，可以操作splitter，且有往左最小会保留图标大小，往右也会有一个限制，不会完全压缩右侧content的内容。
4. 在Left模式下，无论无何调整splitter都不会改变NavigationView的状态(Left, LeftCompact)。

## 讨论

在RsUI部分中有主标题，存在没有icon的NaivgationViewItem，所以在Left模式向左最小化的时候，会存在只保留一个汉字的情况，没有那么美观，但是Ruslan项目都是带有一个icon的NaivgationViewItem。在我的印象中，大部分的开源项目都是会在左侧留有图标。


<img width="1268" height="795" alt="动画3" src="https://github.com/user-attachments/assets/2580d7e1-5267-48a3-af9c-728faa8cd8ab" />
