### PR TITLE
Use WinUI NavigationTransitionInfo for page switch animation

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -69,10 +69,10 @@ class MainWindow: Window {
     }
 
     private lazy var backButton: Button = MainWindow.makeNavButton(glyph: "\u{E72B}") { [weak self] in
-        self?.viewModel.goBack()
+        self?.viewModel.goBack(MainWindow.makeSlideTransition(effect: .fromLeft))
     }
     private lazy var forwardButton: Button = MainWindow.makeNavButton(glyph: "\u{E72A}") { [weak self] in
-        self?.viewModel.goForward()
+        self?.viewModel.goForward(MainWindow.makeSlideTransition(effect: .fromRight))
     }
     private lazy var searchBox: AutoSuggestBox? = {
         // let box = AutoSuggestBox()
@@ -156,19 +156,25 @@ class MainWindow: Window {
         startObserving()
     }
 
-    func navigate(to page: Page) {
-        viewModel.navigate(to: page)
+    private static func makeSlideTransition(effect: SlideNavigationTransitionEffect) -> NavigationTransitionInfo {
+        let transition = SlideNavigationTransitionInfo()
+        transition.effect = effect
+        return transition
     }
 
-    func navigate(to url: URL) -> Bool {
+    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        viewModel.navigate(to: page, transitionInfoOverride: transitionInfoOverride)
+    }
+
+    func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil) -> Bool {
         if url == SettingsPage.url {
-            navigate(to: SettingsPage())
+            navigate(to: SettingsPage(), transitionInfoOverride: transitionInfoOverride)
             return true
         } else {
             let context = WindowContext(owner: self)
             for module in App.context.modules {
                 if let page = module.navigationRequested(for: url, in: context) {
-                    navigate(to: page)
+                    navigate(to: page, transitionInfoOverride: transitionInfoOverride)
                     return true
                 }
             }
@@ -222,13 +228,13 @@ class MainWindow: Window {
             guard let self, let args, !self.isSyncingSelection else { return }
 
             if args.isSettingsSelected {
-                navigate(to: SettingsPage())
+                navigate(to: SettingsPage(), transitionInfoOverride: args.recommendedNavigationTransitionInfo)
             } else if
                 let item = args.selectedItem as? NavigationViewItem,
                 let tag = item.tag,
                 let str = tag as? HString,
                 let url = URL(string: String(hString: str)) {
-                _ = navigate(to: url)
+                _ = navigate(to: url, transitionInfoOverride: args.recommendedNavigationTransitionInfo)
             }
         }
 
@@ -276,14 +282,14 @@ class MainWindow: Window {
                         self.navigationView.header = page.header
                         self.navigationContentFrame.transition(
                             to: page.content,
-                            direction: self.viewModel.navigationDirection
+                            transitionInfo: self.viewModel.navigationTransitionInfo
                         )
-                        self.syncNavigationSelection(for: page)
+                        self.syncNavigationSelection(for: page.url)
                     } else {
                         self.navigationView.header = nil
                         self.navigationContentFrame.transition(
                             to: nil,
-                            direction: self.viewModel.navigationDirection
+                            transitionInfo: self.viewModel.navigationTransitionInfo
                         )
                         self.navigationView.selectedItem = nil
                     }
@@ -295,37 +301,11 @@ class MainWindow: Window {
         }
     }
 
-    private func syncNavigationSelection(for page: Page) {
+    private func syncNavigationSelection(for url: URL) {
         isSyncingSelection = true
         defer { isSyncingSelection = false }
-
-        let urlString = page.url.absoluteString
-
-        if urlString == "rs://ui/settings" {
-            if let settingsItem = navigationView.settingsItem as? NavigationViewItem {
-                settingsItem.isSelected = true
-            }
-            return
-        }
-
-        for item in navigationView.menuItems {
-            if let navItem = item as? NavigationViewItem,
-               let tag = navItem.tag,
-               let str = tag as? HString,
-               String(hString: str) == urlString {
-                navigationView.selectedItem = navItem
-                return
-            }
-        }
-        for item in navigationView.footerMenuItems {
-            if let navItem = item as? NavigationViewItem,
-               let tag = navItem.tag,
-               let str = tag as? HString,
-               String(hString: str) == urlString {
-                navigationView.selectedItem = navItem
-                return
-            }
-        }
+        
+        navigationView.selectItem(with: url)
     }
 
     private func applyAppearance() {

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -127,7 +127,7 @@ class MainWindow: Window {
 
         return bar
     } ()
-    private lazy var navigationContentFrame = Frame()
+    private lazy var navigationContentFrame = PageTransitionHost()
     private lazy var navigationView = {
         let nav = NavigationView()
         nav.paneDisplayMode = .left
@@ -274,11 +274,17 @@ class MainWindow: Window {
                     
                     if let page = self.viewModel.currentPage {
                         self.navigationView.header = page.header
-                        self.navigationContentFrame.content = page.content
-                        self.syncNavigationSelection(for: page.url)
+                        self.navigationContentFrame.transition(
+                            to: page.content,
+                            direction: self.viewModel.navigationDirection
+                        )
+                        self.syncNavigationSelection(for: page)
                     } else {
                         self.navigationView.header = nil
-                        self.navigationContentFrame.content = nil
+                        self.navigationContentFrame.transition(
+                            to: nil,
+                            direction: self.viewModel.navigationDirection
+                        )
                         self.navigationView.selectedItem = nil
                     }
                     
@@ -289,11 +295,37 @@ class MainWindow: Window {
         }
     }
 
-    private func syncNavigationSelection(for url: URL) {
+    private func syncNavigationSelection(for page: Page) {
         isSyncingSelection = true
         defer { isSyncingSelection = false }
 
-        navigationView.selectItem(with: url)
+        let urlString = page.url.absoluteString
+
+        if urlString == "rs://ui/settings" {
+            if let settingsItem = navigationView.settingsItem as? NavigationViewItem {
+                settingsItem.isSelected = true
+            }
+            return
+        }
+
+        for item in navigationView.menuItems {
+            if let navItem = item as? NavigationViewItem,
+               let tag = navItem.tag,
+               let str = tag as? HString,
+               String(hString: str) == urlString {
+                navigationView.selectedItem = navItem
+                return
+            }
+        }
+        for item in navigationView.footerMenuItems {
+            if let navItem = item as? NavigationViewItem,
+               let tag = navItem.tag,
+               let str = tag as? HString,
+               String(hString: str) == urlString {
+                navigationView.selectedItem = navItem
+                return
+            }
+        }
     }
 
     private func applyAppearance() {

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -1,12 +1,7 @@
 import Foundation
 import Observation
+import WinUI
 import RsHelper
-
-enum NavigationDirection {
-    case forward
-    case backward
-    case none
-}
 
 @Observable
 class MainWindowViewModel {
@@ -17,7 +12,7 @@ class MainWindowViewModel {
     var backwardPages: [Page] = []
     var forwardPages: [Page] = []
     var currentPage: Page? = nil
-    var navigationDirection: NavigationDirection = .none
+    var navigationTransitionInfo: NavigationTransitionInfo? = nil
 
     init() {
         windowPosition = App.context.preferences.load(for: WindowPosition.self)
@@ -31,12 +26,11 @@ class MainWindowViewModel {
         App.context.preferences.save(routePreferences)
     }
 
-    func navigate(to page: Page) {
+    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        navigationTransitionInfo = transitionInfoOverride
         if (currentPage === page) { // For refresh current page by appearance change etc.
-            navigationDirection = .none
             currentPage = page
         } else {
-            navigationDirection = .forward
             if let previousPage = currentPage {
                 backwardPages.append(previousPage)
                 if backwardPages.count > routePreferences.maxHistoryPages {
@@ -49,10 +43,10 @@ class MainWindowViewModel {
         }
     }
 
-    func goBack() {
+    func goBack(_ transitionInfoOverride: NavigationTransitionInfo? = nil) {
         guard !backwardPages.isEmpty else { return }
 
-        navigationDirection = .backward
+        navigationTransitionInfo = transitionInfoOverride
         if let page = currentPage {
             forwardPages.append(page)
         }
@@ -60,10 +54,10 @@ class MainWindowViewModel {
         routePreferences.lastPageURL = currentPage?.url
     }
 
-    func goForward() {
+    func goForward(_ transitionInfoOverride: NavigationTransitionInfo? = nil) {
         guard !forwardPages.isEmpty else { return }
 
-        navigationDirection = .forward
+        navigationTransitionInfo = transitionInfoOverride
         if let page = currentPage {
             backwardPages.append(page)
         }

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -2,6 +2,12 @@ import Foundation
 import Observation
 import RsHelper
 
+enum NavigationDirection {
+    case forward
+    case backward
+    case none
+}
+
 @Observable
 class MainWindowViewModel {
     var windowPosition: WindowPosition
@@ -11,6 +17,7 @@ class MainWindowViewModel {
     var backwardPages: [Page] = []
     var forwardPages: [Page] = []
     var currentPage: Page? = nil
+    var navigationDirection: NavigationDirection = .none
 
     init() {
         windowPosition = App.context.preferences.load(for: WindowPosition.self)
@@ -26,8 +33,10 @@ class MainWindowViewModel {
 
     func navigate(to page: Page) {
         if (currentPage === page) { // For refresh current page by appearance change etc.
+            navigationDirection = .none
             currentPage = page
         } else {
+            navigationDirection = .forward
             if let previousPage = currentPage {
                 backwardPages.append(previousPage)
                 if backwardPages.count > routePreferences.maxHistoryPages {
@@ -43,16 +52,18 @@ class MainWindowViewModel {
     func goBack() {
         guard !backwardPages.isEmpty else { return }
 
+        navigationDirection = .backward
         if let page = currentPage {
             forwardPages.append(page)
         }
-        currentPage = backwardPages.removeLast()        
+        currentPage = backwardPages.removeLast()
         routePreferences.lastPageURL = currentPage?.url
     }
 
     func goForward() {
         guard !forwardPages.isEmpty else { return }
 
+        navigationDirection = .forward
         if let page = currentPage {
             backwardPages.append(page)
         }

--- a/Sources/RsUI/Controls/PageTransitionHost.swift
+++ b/Sources/RsUI/Controls/PageTransitionHost.swift
@@ -2,23 +2,18 @@ import UWP
 import WinUI
 import WindowsFoundation
 
-/// 页面切换动画容器。
-/// 用 Grid 叠加新旧内容，通过 Opacity + TranslateX 动画实现方向性过渡。
+/// Hosts page content and applies WinUI-style navigation transition overrides.
 class PageTransitionHost: Grid {
-    // MARK: - 配置
     private let animationDurationMs: Int64 = 200
     private let slideDistance: Double = 40.0
 
-    // MARK: - 状态
     private var isAnimating = false
     private var currentWrapper: Border?
-    private var pendingTransition: (content: UIElement?, direction: NavigationDirection)?
+    private var pendingTransition: (content: UIElement?, transitionInfo: NavigationTransitionInfo?)?
 
-    // MARK: - 公开接口
-
-    func transition(to newContent: UIElement?, direction: NavigationDirection) {
+    func transition(to newContent: UIElement?, transitionInfo: NavigationTransitionInfo? = nil) {
         if isAnimating {
-            pendingTransition = (newContent, direction)
+            pendingTransition = (newContent, transitionInfo)
             return
         }
 
@@ -27,141 +22,179 @@ class PageTransitionHost: Grid {
         guard let newContent else {
             currentWrapper = nil
             if let oldWrapper {
-                runExitAnimation(wrapper: oldWrapper, direction: direction)
+                runExitAnimation(wrapper: oldWrapper, transitionInfo: transitionInfo)
             }
             return
         }
 
         let wrapper = Border()
         let transform = CompositeTransform()
+        let offset = transitionOffset(for: transitionInfo)
+        transform.translateX = offset.x
+        transform.translateY = offset.y
+
         wrapper.child = newContent
         wrapper.renderTransform = transform
         wrapper.opacity = 0
 
-        switch direction {
-        case .forward:  transform.translateX = slideDistance
-        case .backward: transform.translateX = -slideDistance
-        case .none:     transform.translateX = 0
-        }
-
-        self.children.append(wrapper)
+        children.append(wrapper)
         currentWrapper = wrapper
 
-        runTransition(oldWrapper: oldWrapper, newWrapper: wrapper, newTransform: transform, direction: direction)
-    }
+        if transitionInfo is SuppressNavigationTransitionInfo {
+            oldWrapper?.child = nil
+            if let oldWrapper {
+                removeChild(oldWrapper)
+            }
+            wrapper.opacity = 1
+            transform.translateX = 0
+            transform.translateY = 0
+            return
+        }
 
-    // MARK: - 动画实现
+        runTransition(
+            oldWrapper: oldWrapper,
+            newWrapper: wrapper,
+            newTransform: transform,
+            offset: offset
+        )
+    }
 
     private func runTransition(
         oldWrapper: Border?,
         newWrapper: Border,
         newTransform: CompositeTransform,
-        direction: NavigationDirection
+        offset: (x: Double, y: Double)
     ) {
         isAnimating = true
+
         let storyboard = Storyboard()
         let duration = makeDuration(milliseconds: animationDurationMs)
         let easing = CubicEase()
         easing.easingMode = .easeOut
 
-        // 新内容：淡入 + 滑入
-        let newOpacity = DoubleAnimation()
-        newOpacity.from = 0.0
-        newOpacity.to = 1.0
-        newOpacity.duration = duration
-        newOpacity.easingFunction = easing
-        try? Storyboard.setTarget(newOpacity, newWrapper)
-        try? Storyboard.setTargetProperty(newOpacity, "Opacity")
-        storyboard.children.append(newOpacity)
+        addOpacityAnimation(to: storyboard, target: newWrapper, from: 0, to: 1, duration: duration, easing: easing)
+        addSlideAnimation(to: storyboard, target: newTransform, property: "TranslateX", from: offset.x, to: 0, duration: duration, easing: easing)
+        addSlideAnimation(to: storyboard, target: newTransform, property: "TranslateY", from: offset.y, to: 0, duration: duration, easing: easing)
 
-        if direction != .none {
-            let newSlide = DoubleAnimation()
-            newSlide.from = direction == .forward ? slideDistance : -slideDistance
-            newSlide.to = 0.0
-            newSlide.duration = duration
-            newSlide.easingFunction = easing
-            try? Storyboard.setTarget(newSlide, newTransform)
-            try? Storyboard.setTargetProperty(newSlide, "TranslateX")
-            storyboard.children.append(newSlide)
-        }
-
-        // 旧内容：淡出 + 滑出
         if let oldWrapper {
-            let oldTransform = oldWrapper.renderTransform as? CompositeTransform
+            addOpacityAnimation(to: storyboard, target: oldWrapper, from: 1, to: 0, duration: duration, easing: easing)
 
-            let oldOpacity = DoubleAnimation()
-            oldOpacity.from = 1.0
-            oldOpacity.to = 0.0
-            oldOpacity.duration = duration
-            oldOpacity.easingFunction = easing
-            try? Storyboard.setTarget(oldOpacity, oldWrapper)
-            try? Storyboard.setTargetProperty(oldOpacity, "Opacity")
-            storyboard.children.append(oldOpacity)
-
-            if direction != .none, let oldTransform {
-                let oldSlide = DoubleAnimation()
-                oldSlide.from = 0.0
-                oldSlide.to = direction == .forward ? -slideDistance : slideDistance
-                oldSlide.duration = duration
-                oldSlide.easingFunction = easing
-                try? Storyboard.setTarget(oldSlide, oldTransform)
-                try? Storyboard.setTargetProperty(oldSlide, "TranslateX")
-                storyboard.children.append(oldSlide)
+            if let oldTransform = oldWrapper.renderTransform as? CompositeTransform {
+                addSlideAnimation(to: storyboard, target: oldTransform, property: "TranslateX", from: 0, to: -offset.x, duration: duration, easing: easing)
+                addSlideAnimation(to: storyboard, target: oldTransform, property: "TranslateY", from: 0, to: -offset.y, duration: duration, easing: easing)
             }
         }
 
         storyboard.completed.addHandler { [weak self] _, _ in
             guard let self else { return }
+
             if let oldWrapper {
                 oldWrapper.child = nil
                 self.removeChild(oldWrapper)
             }
-            self.isAnimating = false
 
-            if let pending = self.pendingTransition {
-                self.pendingTransition = nil
-                self.transition(to: pending.content, direction: pending.direction)
-            }
+            self.isAnimating = false
+            self.runPendingTransitionIfNeeded()
         }
 
         try? storyboard.begin()
     }
 
-    private func runExitAnimation(wrapper: Border, direction: NavigationDirection) {
+    private func runExitAnimation(wrapper: Border, transitionInfo: NavigationTransitionInfo?) {
+        if transitionInfo is SuppressNavigationTransitionInfo {
+            wrapper.child = nil
+            removeChild(wrapper)
+            return
+        }
+
         isAnimating = true
+
         let storyboard = Storyboard()
         let duration = makeDuration(milliseconds: animationDurationMs)
         let easing = CubicEase()
         easing.easingMode = .easeOut
 
-        let opacity = DoubleAnimation()
-        opacity.from = 1.0
-        opacity.to = 0.0
-        opacity.duration = duration
-        opacity.easingFunction = easing
-        try? Storyboard.setTarget(opacity, wrapper)
-        try? Storyboard.setTargetProperty(opacity, "Opacity")
-        storyboard.children.append(opacity)
+        addOpacityAnimation(to: storyboard, target: wrapper, from: 1, to: 0, duration: duration, easing: easing)
 
         storyboard.completed.addHandler { [weak self] _, _ in
             guard let self else { return }
+
             wrapper.child = nil
             self.removeChild(wrapper)
             self.isAnimating = false
-
-            if let pending = self.pendingTransition {
-                self.pendingTransition = nil
-                self.transition(to: pending.content, direction: pending.direction)
-            }
+            self.runPendingTransitionIfNeeded()
         }
 
         try? storyboard.begin()
     }
 
+    private func runPendingTransitionIfNeeded() {
+        guard let pending = pendingTransition else { return }
+
+        pendingTransition = nil
+        transition(to: pending.content, transitionInfo: pending.transitionInfo)
+    }
+
+    private func transitionOffset(for transitionInfo: NavigationTransitionInfo?) -> (x: Double, y: Double) {
+        guard let slide = transitionInfo as? SlideNavigationTransitionInfo else {
+            return (0, 0)
+        }
+
+        switch slide.effect {
+        case .fromLeft:
+            return (-slideDistance, 0)
+        case .fromRight:
+            return (slideDistance, 0)
+        case .fromBottom:
+            return (0, slideDistance)
+        default:
+            return (0, 0)
+        }
+    }
+
+    private func addOpacityAnimation(
+        to storyboard: Storyboard,
+        target: UIElement,
+        from: Double,
+        to: Double,
+        duration: Duration,
+        easing: CubicEase
+    ) {
+        let animation = DoubleAnimation()
+        animation.from = from
+        animation.to = to
+        animation.duration = duration
+        animation.easingFunction = easing
+        try? Storyboard.setTarget(animation, target)
+        try? Storyboard.setTargetProperty(animation, "Opacity")
+        storyboard.children.append(animation)
+    }
+
+    private func addSlideAnimation(
+        to storyboard: Storyboard,
+        target: CompositeTransform,
+        property: String,
+        from: Double,
+        to: Double,
+        duration: Duration,
+        easing: CubicEase
+    ) {
+        guard from != to else { return }
+
+        let animation = DoubleAnimation()
+        animation.from = from
+        animation.to = to
+        animation.duration = duration
+        animation.easingFunction = easing
+        try? Storyboard.setTarget(animation, target)
+        try? Storyboard.setTargetProperty(animation, property)
+        storyboard.children.append(animation)
+    }
+
     private func removeChild(_ element: UIElement) {
         var idx: UInt32 = 0
-        if self.children.indexOf(element, &idx) {
-            self.children.removeAt(idx)
+        if children.indexOf(element, &idx) {
+            children.removeAt(idx)
         }
     }
 

--- a/Sources/RsUI/Controls/PageTransitionHost.swift
+++ b/Sources/RsUI/Controls/PageTransitionHost.swift
@@ -1,0 +1,174 @@
+import UWP
+import WinUI
+import WindowsFoundation
+
+/// 页面切换动画容器。
+/// 用 Grid 叠加新旧内容，通过 Opacity + TranslateX 动画实现方向性过渡。
+class PageTransitionHost: Grid {
+    // MARK: - 配置
+    private let animationDurationMs: Int64 = 200
+    private let slideDistance: Double = 40.0
+
+    // MARK: - 状态
+    private var isAnimating = false
+    private var currentWrapper: Border?
+    private var pendingTransition: (content: UIElement?, direction: NavigationDirection)?
+
+    // MARK: - 公开接口
+
+    func transition(to newContent: UIElement?, direction: NavigationDirection) {
+        if isAnimating {
+            pendingTransition = (newContent, direction)
+            return
+        }
+
+        let oldWrapper = currentWrapper
+
+        guard let newContent else {
+            currentWrapper = nil
+            if let oldWrapper {
+                runExitAnimation(wrapper: oldWrapper, direction: direction)
+            }
+            return
+        }
+
+        let wrapper = Border()
+        let transform = CompositeTransform()
+        wrapper.child = newContent
+        wrapper.renderTransform = transform
+        wrapper.opacity = 0
+
+        switch direction {
+        case .forward:  transform.translateX = slideDistance
+        case .backward: transform.translateX = -slideDistance
+        case .none:     transform.translateX = 0
+        }
+
+        self.children.append(wrapper)
+        currentWrapper = wrapper
+
+        runTransition(oldWrapper: oldWrapper, newWrapper: wrapper, newTransform: transform, direction: direction)
+    }
+
+    // MARK: - 动画实现
+
+    private func runTransition(
+        oldWrapper: Border?,
+        newWrapper: Border,
+        newTransform: CompositeTransform,
+        direction: NavigationDirection
+    ) {
+        isAnimating = true
+        let storyboard = Storyboard()
+        let duration = makeDuration(milliseconds: animationDurationMs)
+        let easing = CubicEase()
+        easing.easingMode = .easeOut
+
+        // 新内容：淡入 + 滑入
+        let newOpacity = DoubleAnimation()
+        newOpacity.from = 0.0
+        newOpacity.to = 1.0
+        newOpacity.duration = duration
+        newOpacity.easingFunction = easing
+        try? Storyboard.setTarget(newOpacity, newWrapper)
+        try? Storyboard.setTargetProperty(newOpacity, "Opacity")
+        storyboard.children.append(newOpacity)
+
+        if direction != .none {
+            let newSlide = DoubleAnimation()
+            newSlide.from = direction == .forward ? slideDistance : -slideDistance
+            newSlide.to = 0.0
+            newSlide.duration = duration
+            newSlide.easingFunction = easing
+            try? Storyboard.setTarget(newSlide, newTransform)
+            try? Storyboard.setTargetProperty(newSlide, "TranslateX")
+            storyboard.children.append(newSlide)
+        }
+
+        // 旧内容：淡出 + 滑出
+        if let oldWrapper {
+            let oldTransform = oldWrapper.renderTransform as? CompositeTransform
+
+            let oldOpacity = DoubleAnimation()
+            oldOpacity.from = 1.0
+            oldOpacity.to = 0.0
+            oldOpacity.duration = duration
+            oldOpacity.easingFunction = easing
+            try? Storyboard.setTarget(oldOpacity, oldWrapper)
+            try? Storyboard.setTargetProperty(oldOpacity, "Opacity")
+            storyboard.children.append(oldOpacity)
+
+            if direction != .none, let oldTransform {
+                let oldSlide = DoubleAnimation()
+                oldSlide.from = 0.0
+                oldSlide.to = direction == .forward ? -slideDistance : slideDistance
+                oldSlide.duration = duration
+                oldSlide.easingFunction = easing
+                try? Storyboard.setTarget(oldSlide, oldTransform)
+                try? Storyboard.setTargetProperty(oldSlide, "TranslateX")
+                storyboard.children.append(oldSlide)
+            }
+        }
+
+        storyboard.completed.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            if let oldWrapper {
+                oldWrapper.child = nil
+                self.removeChild(oldWrapper)
+            }
+            self.isAnimating = false
+
+            if let pending = self.pendingTransition {
+                self.pendingTransition = nil
+                self.transition(to: pending.content, direction: pending.direction)
+            }
+        }
+
+        try? storyboard.begin()
+    }
+
+    private func runExitAnimation(wrapper: Border, direction: NavigationDirection) {
+        isAnimating = true
+        let storyboard = Storyboard()
+        let duration = makeDuration(milliseconds: animationDurationMs)
+        let easing = CubicEase()
+        easing.easingMode = .easeOut
+
+        let opacity = DoubleAnimation()
+        opacity.from = 1.0
+        opacity.to = 0.0
+        opacity.duration = duration
+        opacity.easingFunction = easing
+        try? Storyboard.setTarget(opacity, wrapper)
+        try? Storyboard.setTargetProperty(opacity, "Opacity")
+        storyboard.children.append(opacity)
+
+        storyboard.completed.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            wrapper.child = nil
+            self.removeChild(wrapper)
+            self.isAnimating = false
+
+            if let pending = self.pendingTransition {
+                self.pendingTransition = nil
+                self.transition(to: pending.content, direction: pending.direction)
+            }
+        }
+
+        try? storyboard.begin()
+    }
+
+    private func removeChild(_ element: UIElement) {
+        var idx: UInt32 = 0
+        if self.children.indexOf(element, &idx) {
+            self.children.removeAt(idx)
+        }
+    }
+
+    private func makeDuration(milliseconds: Int64) -> Duration {
+        Duration(
+            timeSpan: TimeSpan(duration: milliseconds * 10_000),
+            type: .timeSpan
+        )
+    }
+}

--- a/Sources/RsUI/Models/WindowContext.swift
+++ b/Sources/RsUI/Models/WindowContext.swift
@@ -1,7 +1,8 @@
-﻿import Foundation
+import Foundation
 import WinAppSDK
+import WinUI
 
-/// 模块所附窗口上下文信息
+/// Window context exposed to modules.
 public struct WindowContext {
     let owner: MainWindow
 
@@ -17,11 +18,11 @@ public struct WindowContext {
         }
     }
 
-    public func navigate(to page: Page) {
-        owner.navigate(to: page)
+    public func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        owner.navigate(to: page, transitionInfoOverride: transitionInfoOverride)
     }
 
-    public func navigate(to url: URL) -> Bool {
-        return owner.navigate(to: url)
+    public func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil) -> Bool {
+        return owner.navigate(to: url, transitionInfoOverride: transitionInfoOverride)
     }
 }


### PR DESCRIPTION
ISSUE #34 

## 修改页面切换动画的实现方式，使其更贴近 WinUI 的导航 API 设计。

### 问题1

syncNavigationSelection 的修改确实没有必要，并且甚至实现的没有原来的navigationView.selectItem(with:)好，我会恢复为调用 navigationView.selectItem(with:)。

### 问题2

关于动画方向，我会移除自定义 NavigationDirection，改用 WinUI 的 NavigationTransitionInfo，并让导航接口接近 Frame.Navigate(..., NavigationTransitionInfo?)。

### 问题3

这个 PR 暂时不移动 NavigationView.header。

WinUI Gallery 中的实现方式是Header和Content都是在Frame中的，所以会看到Header和Content会同时执行一种动画。

当前 RsUI 的 Page.header 类型是 Any?，并且现有页面依赖 NavigationView.Header 来完成 header 的展示。我的想法是，将其取消并在Content中创建一个相应的HeaderPresenter。

