### PR TITLE
fix(PageTransitionHost): 推迟visual tree的清理到下一个调度器帧执行，避免崩溃。

### DIFF
--- a/Sources/RsUI/Controls/PageTransitionHost.swift
+++ b/Sources/RsUI/Controls/PageTransitionHost.swift
@@ -87,14 +87,15 @@ class PageTransitionHost: Grid {
 
         storyboard.completed.addHandler { [weak self] _, _ in
             guard let self else { return }
-
-            if let oldWrapper {
-                oldWrapper.child = nil
-                self.removeChild(oldWrapper)
+            try? self.dispatcherQueue?.tryEnqueue { [weak self] in
+                guard let self else { return }
+                if let oldWrapper {
+                    oldWrapper.child = nil
+                    self.removeChild(oldWrapper)
+                }
+                self.isAnimating = false
+                self.runPendingTransitionIfNeeded()
             }
-
-            self.isAnimating = false
-            self.runPendingTransitionIfNeeded()
         }
 
         try? storyboard.begin()
@@ -118,11 +119,13 @@ class PageTransitionHost: Grid {
 
         storyboard.completed.addHandler { [weak self] _, _ in
             guard let self else { return }
-
-            wrapper.child = nil
-            self.removeChild(wrapper)
-            self.isAnimating = false
-            self.runPendingTransitionIfNeeded()
+            try? self.dispatcherQueue?.tryEnqueue { [weak self] in
+                guard let self else { return }
+                wrapper.child = nil
+                self.removeChild(wrapper)
+                self.isAnimating = false
+                self.runPendingTransitionIfNeeded()
+            }
         }
 
         try? storyboard.begin()


### PR DESCRIPTION
## 问题描述

`storyboard.completed` 回调中直接执行 `oldWrapper.child = nil` 和 `removeChild`，在应用启动时首次页面切换动画完成的瞬间（约 200ms），若 WinUI 正处于内部 Layout/Rendering pass，`Border.child` setter 的底层 COM 调用会以 `0x80070057` (E_INVALIDARG) 失败，触发 swift-winui binding 的 `try!`，导致概率性崩溃。

`runTransition` 和 `runExitAnimation` 均存在此问题。

## 修复方式

将 `completed` 回调中的视觉树操作通过 `dispatcherQueue.tryEnqueue` 推迟到下一个 dispatcher 帧执行，确保脱离当前 WinUI 渲染上下文后再修改控件树。

## 更改的文件

- `Sources/RsUI/Controls/PageTransitionHost.swift`