### PR TITLE
feat: 页面 header 跟随 content 一起执行转场动画

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -128,6 +128,8 @@ class MainWindow: Window {
         return bar
     } ()
     private lazy var navigationContentFrame = PageTransitionHost()
+    private var pageViewContentBorder: Border?
+    private var pageViewHeaderBorder: Border?
     private lazy var navigationView = {
         let nav = NavigationView()
         nav.paneDisplayMode = .left
@@ -279,9 +281,9 @@ class MainWindow: Window {
                     guard let self else { return }
                     
                     if let page = self.viewModel.currentPage {
-                        self.navigationView.header = page.header
+                        self.navigationView.header = nil
                         self.navigationContentFrame.transition(
-                            to: page.content,
+                            to: self.makePageView(page),
                             transitionInfo: self.viewModel.navigationTransitionInfo
                         )
                         self.syncNavigationSelection(for: page.url)
@@ -299,6 +301,53 @@ class MainWindow: Window {
                 }
             }
         }
+    }
+
+    private func makePageView(_ page: Page) -> UIElement {
+        pageViewContentBorder?.child = nil
+        pageViewHeaderBorder?.child = nil
+        pageViewContentBorder = nil
+        pageViewHeaderBorder = nil
+
+        guard let header = page.header else {
+            return page.content
+        }
+
+        let grid = Grid()
+        let autoRow = RowDefinition()
+        autoRow.height = GridLength(value: 0, gridUnitType: .auto)
+        let starRow = RowDefinition()
+        starRow.height = GridLength(value: 1, gridUnitType: .star)
+        grid.rowDefinitions.append(autoRow)
+        grid.rowDefinitions.append(starRow)
+
+        // Row 0: header, margin matches NavigationViewHeaderMargin (56,44,0,0)
+        let headerBorder = Border()
+        headerBorder.margin = Thickness(left: 56, top: 44, right: 0, bottom: 0)
+        if let text = header as? String {
+            let tb = TextBlock()
+            tb.text = text
+            tb.fontSize = 28
+            tb.fontWeight = FontWeights.semiBold
+            tb.textWrapping = .wrap
+            headerBorder.child = tb
+        } else if let view = header as? UIElement {
+            headerBorder.child = view
+            pageViewHeaderBorder = headerBorder
+        } else {
+            return page.content
+        }
+
+        // Row 1: content
+        let contentBorder = Border()
+        contentBorder.child = page.content
+        pageViewContentBorder = contentBorder
+
+        try? Grid.setRow(headerBorder, 0)
+        try? Grid.setRow(contentBorder, 1)
+        grid.children.append(headerBorder)
+        grid.children.append(contentBorder)
+        return grid
     }
 
     private func syncNavigationSelection(for url: URL) {


### PR DESCRIPTION
 ## 背景

原实现将 `page.header` 设置在 `NavigationView.Header` 属性上，该区域属于 NavigationView 的固定 chrome，不参与 `PageTransitionHost`，的动画，导致切换页面时只有内容滑动、标题静止。

WinUI3 Gallery 的做法是不使用 `NavigationView.Header`，将页面标题直接写在页面内容中，从而让标题与内容一起运动。

## 改动

- `NavigationView.header` 始终设为 `nil`
- 新增 `makePageView(_:)` 方法，将 `page.header` 与 `page.content`合并为一个两行 Grid（Row 0 Auto = header，Row 1 * = content），整体传入 `PageTransitionHost` 做动画
- header 为 `UIElement` 时直接使用；header 为 `nil` 时返回原始 content，行为不变
- 追踪上一次创建的 `pageViewContentBorder` / `pageViewHeaderBorder`，在每次 `makePageView` 前先将其 `child` 清空，避免页面缓存 UIElement 实例时触发 WinUI E_INVALIDARG（`0x80070057`）崩溃。