### PR TITLE
fix(MainWindow): 跳过启动时首个页面的转场动画

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -130,6 +130,7 @@ class MainWindow: Window {
     private lazy var navigationContentFrame = PageTransitionHost()
     private var pageViewContentBorder: Border?
     private var pageViewHeaderBorder: Border?
+    private var isFirstNavigation = true
     private lazy var navigationView = {
         let nav = NavigationView()
         nav.paneDisplayMode = .left
@@ -279,12 +280,19 @@ class MainWindow: Window {
             for await _ in route {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    
+
                     if let page = self.viewModel.currentPage {
                         self.navigationView.header = nil
+                        let effectiveTransitionInfo: NavigationTransitionInfo?
+                        if isFirstNavigation {
+                            effectiveTransitionInfo = SuppressNavigationTransitionInfo()
+                            isFirstNavigation = false
+                        } else {
+                            effectiveTransitionInfo = self.viewModel.navigationTransitionInfo
+                        }
                         self.navigationContentFrame.transition(
                             to: self.makePageView(page),
-                            transitionInfo: self.viewModel.navigationTransitionInfo
+                            transitionInfo: effectiveTransitionInfo
                         )
                         self.syncNavigationSelection(for: page.url)
                     } else {


### PR DESCRIPTION
程序启动后载入第一个页面时，使用 `SuppressNavigationTransitionInfo` 跳过转场动画，页面直接显示