### PR TITLE
Controls/about settings

### DIFF
--- a/Sources/RsUI/App/Settings/SettingsPage.swift
+++ b/Sources/RsUI/App/Settings/SettingsPage.swift
@@ -102,14 +102,17 @@ class SettingsPage: Page {
         let wasdk = HyperlinkButton()
         wasdk.content = "Windows App SDK \(App.context.winAppSDKVersion)"
         wasdk.navigateUri = Uri("https://aka.ms/windowsappsdk")
+        wasdk.padding = WinUI.Thickness(left: 0, top: 4, right: 0, bottom: 4)
 
         let winui = HyperlinkButton()
         winui.content = "WinUI 3"
         winui.navigateUri = Uri("https://aka.ms/winui")
-        
+        winui.padding = WinUI.Thickness(left: 0, top: 4, right: 0, bottom: 4)
+
         let winrt = HyperlinkButton()
         winrt.content = "Swift/WinRT"
         winrt.navigateUri = Uri("https://github.com/thebrowsercompany/swift-winrt")
+        winrt.padding = WinUI.Thickness(left: 0, top: 4, right: 0, bottom: 4)
 
         let depends = WinUI.StackPanel()
         depends.children.append(wasdk)

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -202,7 +202,6 @@ public class SettingsCard: ButtonBase {
 
     private func enableInteraction() {
         disableInteraction()
-        let isDark: Bool = App.context.theme.isDark
 
         pointerEnteredToken = pointerEntered.addHandler { [weak self] _, _ in
             self?.goToPointerOverState()

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -40,7 +40,7 @@ public class SettingsCard: ButtonBase {
 
     let cardBorder = WinUI.Border()
     private var rootGrid: WinUI.Grid?
-    private var actionIconHolder: FrameworkElement?
+    private var actionIconHolder: Viewbox?
 
     // MARK: - Init
 
@@ -54,11 +54,16 @@ public class SettingsCard: ButtonBase {
         self.horizontalContentAlignment = .stretch
         self.verticalContentAlignment = .stretch
 
+        cardBorder.minWidth = 148
+        cardBorder.minHeight = 68
+        cardBorder.padding = WinUI.Thickness(left: 16, top: 16, right: 16, bottom: 16)
+        cardBorder.horizontalAlignment = .stretch
+        cardBorder.verticalAlignment = .center
+        cardBorder.backgroundSizing = .innerBorderEdge
+        cardBorder.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
+        cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 4, topRight: 4, bottomRight: 8, bottomLeft: 4)
         cardBorder.background = cardBackgroundBrush(isDark: isDark)
         cardBorder.borderBrush = cardBorderBrush(isDark: isDark)
-        cardBorder.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
-        cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
-        cardBorder.padding = WinUI.Thickness(left: 16, top: 16, right: 16, bottom: 16)
 
         self.content = cardBorder
     }
@@ -226,7 +231,7 @@ public class SettingsCard: ButtonBase {
 
         // Columns: [icon] [text*] [content auto] [actionIcon auto]
         let iconCol = WinUI.ColumnDefinition()
-        iconCol.width = WinUI.GridLength(value: headerIcon != nil ? 40 : 0, gridUnitType: .pixel)
+        iconCol.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
         container.columnDefinitions.append(iconCol)
 
         let textCol = WinUI.ColumnDefinition()
@@ -243,14 +248,14 @@ public class SettingsCard: ButtonBase {
 
         // Rows: [header auto] [description auto]
         let headerRow = WinUI.RowDefinition()
-        headerRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
+        headerRow.height = WinUI.GridLength(value: 1, gridUnitType: .star)
         container.rowDefinitions.append(headerRow)
 
         let descRow = WinUI.RowDefinition()
         descRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
         container.rowDefinitions.append(descRow)
 
-        // Header icon (col 0, spans both rows)
+        // Header Icon Holder (col 0, spans both rows)
         if let icon = headerIcon {
             if let fontIcon = icon as? WinUI.FontIcon {
                 fontIcon.fontSize = 20
@@ -259,11 +264,28 @@ public class SettingsCard: ButtonBase {
                 imageIcon.height = 24
             }
             icon.verticalAlignment = .center
-            container.children.append(icon)
-            try? WinUI.Grid.setRow(icon, 0)
-            try? WinUI.Grid.setColumn(icon, 0)
-            try? WinUI.Grid.setRowSpan(icon, 2)
+
+            // HeaderIconHolder
+            let headerIconHolder: Viewbox = WinUI.Viewbox()
+            headerIconHolder.width = 20
+            headerIconHolder.height = 20
+            headerIconHolder.margin = WinUI.Thickness(left: 2, top: 0, right: 20, bottom: 0)
+            headerIconHolder.verticalAlignment = .center
+            headerIconHolder.stretch = .uniform
+            headerIconHolder.child = icon
+            container.children.append(headerIconHolder)
+            try? WinUI.Grid.setRow(headerIconHolder, 0)
+            try? WinUI.Grid.setColumn(headerIconHolder, 0)
         }
+
+        // Header Panel
+        let headerPanel: StackPanel = WinUI.StackPanel()
+        headerPanel.orientation = .vertical
+        headerPanel.verticalAlignment = .center
+        headerPanel.margin = WinUI.Thickness(left: 0, top: 0, right: 24, bottom: 0)
+        try? WinUI.Grid.setRow(headerPanel, 0)
+        try? WinUI.Grid.setColumn(headerPanel, 1)
+        container.children.append(headerPanel)
 
         // Header label (col 1, row 0)
         if let headerText = header, !headerText.isEmpty {
@@ -271,10 +293,8 @@ public class SettingsCard: ButtonBase {
             titleLabel.text = headerText
             titleLabel.fontSize = 14
             titleLabel.textWrapping = .wrap
-            titleLabel.margin = WinUI.Thickness(left: headerIcon != nil ? 16 : 0, top: 0, right: 0, bottom: 2)
-            container.children.append(titleLabel)
-            try? WinUI.Grid.setRow(titleLabel, 0)
-            try? WinUI.Grid.setColumn(titleLabel, 1)
+            titleLabel.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+            headerPanel.children.append(titleLabel)
         }
 
         // Description (col 1, row 1)
@@ -283,13 +303,11 @@ public class SettingsCard: ButtonBase {
                 tb.foreground = secondaryForeground
                 tb.fontSize = 12
                 tb.textWrapping = .wrap
-                tb.margin = WinUI.Thickness(left: headerIcon != nil ? 16 : 0, top: 0, right: 0, bottom: 0)
+                tb.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
             } else {
-                desc.margin = WinUI.Thickness(left: headerIcon != nil ? 16 : 0, top: 0, right: 0, bottom: 0)
+                desc.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
             }
-            container.children.append(desc)
-            try? WinUI.Grid.setRow(desc, 1)
-            try? WinUI.Grid.setColumn(desc, 1)
+            headerPanel.children.append(desc)
         }
 
         // Right-side content (col 2, spans both rows) — only shown in .right alignment
@@ -304,19 +322,29 @@ public class SettingsCard: ButtonBase {
         // Action icon (col 3, spans both rows) — only when isClickEnabled && isActionIconVisible
         let effectiveActionIcon = actionIcon ?? self.actionIcon
         if let aIcon = effectiveActionIcon {
+            // actionIconHolder
+            let actionIconHolder: Viewbox = Viewbox()
+            actionIconHolder.width = 13
+            actionIconHolder.height = 13
+            actionIconHolder.margin = WinUI.Thickness(left: 14, top: 0, right: 0, bottom: 0)
+            actionIconHolder.horizontalAlignment = .center
+            actionIconHolder.verticalAlignment = .center
+            actionIconHolder.stretch = .uniform
+            
             aIcon.fontSize = 13
-            aIcon.margin = WinUI.Thickness(left: 14, top: 0, right: 0, bottom: 0)
+            aIcon.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
             aIcon.verticalAlignment = .center
             if let toolTip = actionIconToolTip {
                 // ToolTipService not directly available in this API; store for future use
                 _ = toolTip
             }
-            aIcon.visibility = (isClickEnabled && isActionIconVisible) ? .visible : .collapsed
-            container.children.append(aIcon)
-            try? WinUI.Grid.setRow(aIcon, 0)
-            try? WinUI.Grid.setColumn(aIcon, 3)
-            try? WinUI.Grid.setRowSpan(aIcon, 2)
-            actionIconHolder = aIcon
+
+            actionIconHolder.visibility = (isClickEnabled && isActionIconVisible) ? .visible : .collapsed
+            actionIconHolder.child = aIcon
+            self.actionIconHolder = actionIconHolder
+            container.children.append(actionIconHolder)
+            try? WinUI.Grid.setRowSpan(actionIconHolder, 2)
+            try? WinUI.Grid.setColumn(actionIconHolder, 3)
         }
 
         rootGrid = container

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -42,6 +42,14 @@ public class SettingsCard: ButtonBase {
     private var rootGrid: WinUI.Grid?
     private var actionIconHolder: Viewbox?
 
+    // Event cleanups for proper handler removal
+    private var pointerEnteredToken: EventCleanup?
+    private var pointerExitedToken: EventCleanup?
+    private var pointerPressedToken: EventCleanup?
+    private var pointerReleasedToken: EventCleanup?
+    private var pointerCaptureLostToken: EventCleanup?
+    private var pointerCanceledToken: EventCleanup?
+
     // MARK: - Init
 
     private override init() {
@@ -180,9 +188,9 @@ public class SettingsCard: ButtonBase {
     private func onIsClickEnabledChanged() {
         updateActionIconVisibility()
         if isClickEnabled {
-            enableHoverInteraction()
+            enableInteraction()
         } else {
-            disableHoverInteraction()
+            disableInteraction()
         }
     }
 
@@ -191,28 +199,55 @@ public class SettingsCard: ButtonBase {
         holder.visibility = (isClickEnabled && isActionIconVisible) ? .visible : .collapsed
     }
 
-    private func enableHoverInteraction() {
-        disableHoverInteraction()
-        let isDark = App.context.theme.isDark
-        pointerEntered.addHandler { [weak self] _, _ in
-            self?.cardBorder.background = cardHoverBrush(isDark: isDark)
+    private func enableInteraction() {
+        disableInteraction()
+        let isDark: Bool = App.context.theme.isDark
+
+        pointerEnteredToken = pointerEntered.addHandler { [weak self] _, _ in
+            self?.goToPointerOverState()
         }
-        pointerExited.addHandler { [weak self] _, _ in
-            self?.cardBorder.background = cardBackgroundBrush(isDark: isDark)
+        pointerExitedToken = pointerExited.addHandler { [weak self] _, _ in
+            self?.goToNormalState()
         }
-        pointerPressed.addHandler { [weak self] _, _ in
-            self?.cardBorder.background = cardPressedBrush(isDark: isDark)
+        pointerPressedToken = pointerPressed.addHandler { [weak self] _, _ in
+            self?.goToPressedState()
         }
-        pointerReleased.addHandler { [weak self] _, _ in
-            self?.cardBorder.background = cardBackgroundBrush(isDark: isDark)
+        pointerReleasedToken = pointerReleased.addHandler { [weak self] _, _ in
+            self?.goToNormalState()
+        }
+        pointerCaptureLostToken = pointerCaptureLost.addHandler { [weak self] _, _ in
+            self?.goToNormalState()
+        }
+        pointerCanceledToken = pointerCanceled.addHandler { [weak self] _, _ in
+            self?.goToNormalState()
         }
     }
 
-    private func disableHoverInteraction() {
-        // WinUI event tokens are not easily removable without storing them;
-        // reassign background to reset visual state.
+    private func disableInteraction() {
+        pointerEnteredToken?.dispose(); pointerEnteredToken = nil
+        pointerExitedToken?.dispose(); pointerExitedToken = nil
+        pointerPressedToken?.dispose(); pointerPressedToken = nil
+        pointerReleasedToken?.dispose(); pointerReleasedToken = nil
+        pointerCaptureLostToken?.dispose(); pointerCaptureLostToken = nil
+        pointerCanceledToken?.dispose(); pointerCanceledToken = nil
+
+        goToNormalState()
+    }
+
+    // Visual state transitions
+    private func goToNormalState() {
         let isDark = App.context.theme.isDark
         cardBorder.background = cardBackgroundBrush(isDark: isDark)
+    }
+
+    private func goToPointerOverState() {
+        let isDark = App.context.theme.isDark
+        cardBorder.background = cardHoverBrush(isDark: isDark)
+    }
+
+    private func goToPressedState() {
+        let isDark = App.context.theme.isDark
+        cardBorder.background = cardPressedBrush(isDark: isDark)
     }
 
     // MARK: - Layout builder
@@ -246,7 +281,7 @@ public class SettingsCard: ButtonBase {
         actionCol.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
         container.columnDefinitions.append(actionCol)
 
-        // Rows: [header auto] [description auto]
+        // Rows: [header row*] [content/description row auto]
         let headerRow = WinUI.RowDefinition()
         headerRow.height = WinUI.GridLength(value: 1, gridUnitType: .star)
         container.rowDefinitions.append(headerRow)
@@ -255,8 +290,13 @@ public class SettingsCard: ButtonBase {
         descRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
         container.rowDefinitions.append(descRow)
 
-        // Header Icon Holder (col 0, spans both rows)
-        if let icon = headerIcon {
+        // Determine visibility based on contentAlignment
+        let showHeaderIcon = (contentAlignment != .left) && (headerIcon != nil)
+        let showHeaderText = (contentAlignment != .left) && (header != nil && !header!.isEmpty)
+        let showDescription = (contentAlignment != .left) && (description != nil)
+
+        // Header Icon Holder (col 0, row 0)
+        if showHeaderIcon, let icon = headerIcon {
             if let fontIcon = icon as? WinUI.FontIcon {
                 fontIcon.fontSize = 20
             } else if let imageIcon = icon as? ImageIcon {
@@ -265,7 +305,6 @@ public class SettingsCard: ButtonBase {
             }
             icon.verticalAlignment = .center
 
-            // HeaderIconHolder
             let headerIconHolder: Viewbox = WinUI.Viewbox()
             headerIconHolder.width = 20
             headerIconHolder.height = 20
@@ -278,51 +317,75 @@ public class SettingsCard: ButtonBase {
             try? WinUI.Grid.setColumn(headerIconHolder, 0)
         }
 
-        // Header Panel
-        let headerPanel: StackPanel = WinUI.StackPanel()
-        headerPanel.orientation = .vertical
-        headerPanel.verticalAlignment = .center
-        headerPanel.margin = WinUI.Thickness(left: 0, top: 0, right: 24, bottom: 0)
-        try? WinUI.Grid.setRow(headerPanel, 0)
-        try? WinUI.Grid.setColumn(headerPanel, 1)
-        container.children.append(headerPanel)
+        // Header Panel (col 1, row 0)
+        if showHeaderText || showDescription {
+            let headerPanel: StackPanel = WinUI.StackPanel()
+            headerPanel.orientation = .vertical
+            headerPanel.verticalAlignment = .center
+            headerPanel.margin = (contentAlignment == .right)
+                ? WinUI.Thickness(left: 0, top: 0, right: 24, bottom: 0)
+                : WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+            try? WinUI.Grid.setRow(headerPanel, 0)
+            try? WinUI.Grid.setColumn(headerPanel, 1)
+            container.children.append(headerPanel)
 
-        // Header label (col 1, row 0)
-        if let headerText = header, !headerText.isEmpty {
-            let titleLabel = WinUI.TextBlock()
-            titleLabel.text = headerText
-            titleLabel.fontSize = 14
-            titleLabel.textWrapping = .wrap
-            titleLabel.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
-            headerPanel.children.append(titleLabel)
-        }
-
-        // Description (col 1, row 1)
-        if let desc = description {
-            if let tb = desc as? TextBlock {
-                tb.foreground = secondaryForeground
-                tb.fontSize = 12
-                tb.textWrapping = .wrap
-                tb.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
-            } else {
-                desc.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+            // Header label
+            if showHeaderText, let headerText = header {
+                let titleLabel = WinUI.TextBlock()
+                titleLabel.text = headerText
+                titleLabel.fontSize = 14
+                titleLabel.textWrapping = .wrap
+                titleLabel.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+                headerPanel.children.append(titleLabel)
             }
-            headerPanel.children.append(desc)
+
+            // Description
+            if showDescription, let desc = description {
+                if let tb = desc as? TextBlock {
+                    tb.foreground = secondaryForeground
+                    tb.fontSize = 12
+                    tb.textWrapping = .wrap
+                    tb.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+                } else {
+                    desc.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
+                }
+                headerPanel.children.append(desc)
+            }
         }
 
-        // Right-side content (col 2, spans both rows) — only shown in .right alignment
-        if let ctrl = content, contentAlignment == .right {
-            ctrl.verticalAlignment = .center
-            container.children.append(ctrl)
-            try? WinUI.Grid.setRow(ctrl, 0)
-            try? WinUI.Grid.setColumn(ctrl, 2)
-            try? WinUI.Grid.setRowSpan(ctrl, 2)
+        // Content placement based on contentAlignment
+        if let ctrl = content {
+            switch contentAlignment {
+            case .right:
+                // Content in col 2, row 0, right-aligned
+                ctrl.verticalAlignment = .center
+                ctrl.horizontalAlignment = .right
+                container.children.append(ctrl)
+                try? WinUI.Grid.setRow(ctrl, 0)
+                try? WinUI.Grid.setColumn(ctrl, 2)
+                try? WinUI.Grid.setRowSpan(ctrl, 2)
+
+            case .left:
+                // Content in col 1, row 1, left-aligned
+                ctrl.horizontalAlignment = .left
+                ctrl.verticalAlignment = .center
+                container.children.append(ctrl)
+                try? WinUI.Grid.setRow(ctrl, 1)
+                try? WinUI.Grid.setColumn(ctrl, 1)
+
+            case .vertical:
+                // Content in col 1, row 1, stretch horizontally
+                ctrl.horizontalAlignment = .stretch
+                ctrl.verticalAlignment = .center
+                container.children.append(ctrl)
+                try? WinUI.Grid.setRow(ctrl, 1)
+                try? WinUI.Grid.setColumn(ctrl, 1)
+            }
         }
 
-        // Action icon (col 3, spans both rows) — only when isClickEnabled && isActionIconVisible
+        // Action icon (col 3, spans both rows)
         let effectiveActionIcon = actionIcon ?? self.actionIcon
         if let aIcon = effectiveActionIcon {
-            // actionIconHolder
             let actionIconHolder: Viewbox = Viewbox()
             actionIconHolder.width = 13
             actionIconHolder.height = 13
@@ -330,13 +393,14 @@ public class SettingsCard: ButtonBase {
             actionIconHolder.horizontalAlignment = .center
             actionIconHolder.verticalAlignment = .center
             actionIconHolder.stretch = .uniform
-            
+
             aIcon.fontSize = 13
             aIcon.margin = WinUI.Thickness(left: 0, top: 0, right: 0, bottom: 0)
             aIcon.verticalAlignment = .center
-            if let toolTip = actionIconToolTip {
-                // ToolTipService not directly available in this API; store for future use
-                _ = toolTip
+
+            // Apply ToolTip if available
+            if let toolTip = actionIconToolTip, !toolTip.isEmpty {
+                try? WinUI.ToolTipService.setToolTip(actionIconHolder, toolTip)
             }
 
             actionIconHolder.visibility = (isClickEnabled && isActionIconVisible) ? .visible : .collapsed

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -3,15 +3,51 @@ import UWP
 import WinAppSDK
 import WinUI
 
+/// ContentAlignment controls where the content is placed within SettingsCard.
+public enum SettingsCardContentAlignment {
+    /// Content is aligned to the right. Default state.
+    case right
+    /// Content is left-aligned; Header, HeaderIcon and Description are hidden.
+    case left
+    /// Content is vertically aligned below Header/Description.
+    case vertical
+}
+
+/// A card control for consistent settings UI, matching the Windows 11 design language.
+/// Can be used standalone or hosted inside a SettingsExpander.
 public class SettingsCard: ButtonBase {
-    public var isClickEnabled = false
+
+    // MARK: - Properties
+
+    public var header: Any?
+    public var description: Any?
+    public var headerIcon: IconElement?
+    public var actionIcon: FontIcon? = {
+        let icon = WinUI.FontIcon()
+        icon.glyph = "\u{E974}" // ChevronRight
+        return icon
+    }()
+    public var actionIconToolTip: String?
+    public var isClickEnabled: Bool = false {
+        didSet { onIsClickEnabledChanged() }
+    }
+    public var contentAlignment: SettingsCardContentAlignment = .right
+    public var isActionIconVisible: Bool = true {
+        didSet { updateActionIconVisibility() }
+    }
+
+    // MARK: - Internal layout parts
 
     let cardBorder = WinUI.Border()
+    private var rootGrid: WinUI.Grid?
+    private var actionIconHolder: FrameworkElement?
+
+    // MARK: - Init
 
     private override init() {
         super.init()
 
-        let isDark = App.context.theme.isDark
+        let isDark: Bool = App.context.theme.isDark
 
         self.horizontalAlignment = .stretch
         self.verticalAlignment = .stretch
@@ -22,67 +58,105 @@ public class SettingsCard: ButtonBase {
         cardBorder.borderBrush = cardBorderBrush(isDark: isDark)
         cardBorder.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
         cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
-        cardBorder.padding = WinUI.Thickness(left: 10, top: 10, right: 10, bottom: 10)
+        cardBorder.padding = WinUI.Thickness(left: 16, top: 16, right: 16, bottom: 16)
 
         self.content = cardBorder
     }
 
-    public convenience init(_ headerIconGlyph: String, _ header: String, _ description: String, _ content: FrameworkElement, _ actionIcon: FontIcon? = nil) {
+
+    /// Header + description (text) + right-side content control, with a glyph icon.
+    public convenience init(
+        headerIconGlyph: String,
+        header: String,
+        description: String? = nil,
+        content: FrameworkElement? = nil,
+        actionIcon: FontIcon? = nil
+    ) {
         self.init()
+        self.header = header
+        self.description = description
+        self.actionIcon = actionIcon
 
         let icon = WinUI.FontIcon()
         icon.glyph = headerIconGlyph
+        self.headerIcon = icon
 
-        let textBlock: TextBlock = (try? XamlReader.load("""
-            <TextBlock xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" >
-            \(description)
-            </TextBlock>
-            """)) as? TextBlock ?? {
-            let tb = TextBlock()
-            tb.text = description
-            return tb
-        }()
-
-        cardBorder.child = build(
+        cardBorder.child = buildLayout(
             headerIcon: icon,
             header: header,
-            description: textBlock,
+            description: makeDescriptionView(description),
             content: content,
             actionIcon: actionIcon
         )
     }
 
-    public convenience init(_ headerIconPath: String, _ header: String, _ description: String, _ content: String, _ actionIcon: FontIcon) {
+    /// Header + description (text) + right-side text content, with an image icon.
+    public convenience init(
+        headerIconPath: String,
+        header: String,
+        description: String? = nil,
+        contentText: String? = nil,
+        actionIcon: FontIcon? = nil
+    ) {
         self.init()
+        self.header = header
+        self.description = description
+        self.actionIcon = actionIcon
 
         let bitmap = BitmapImage()
         bitmap.uriSource = Uri(headerIconPath)
         let icon = ImageIcon()
         icon.source = bitmap
-        let descTextBlock = TextBlock()
-        descTextBlock.text = description
-        let contentTextBlock = TextBlock()
-        contentTextBlock.text = content
+        self.headerIcon = icon
 
-        cardBorder.child = build(
+        let contentView: FrameworkElement? = contentText.map {
+            let tb = TextBlock()
+            tb.text = $0
+            return tb
+        }
+
+        cardBorder.child = buildLayout(
             headerIcon: icon,
             header: header,
-            description: descTextBlock,
-            content: contentTextBlock,
+            description: makeDescriptionView(description),
+            content: contentView,
             actionIcon: actionIcon
         )
     }
 
-    public convenience init(_ header: String, _ description: FrameworkElement) {
+    /// Header only, with a right-side content control (no icon).
+    public convenience init(
+        header: String,
+        description: FrameworkElement? = nil,
+        content: FrameworkElement? = nil,
+        actionIcon: FontIcon? = nil
+    ) {
         self.init()
+        self.header = header
+        self.description = description
+        self.actionIcon = actionIcon
 
-        cardBorder.child = build(
+        cardBorder.child = buildLayout(
             header: header,
-            description: description
+            description: description,
+            content: content,
+            actionIcon: actionIcon
         )
     }
 
-    // Remove card border/background for use as an inner item inside SettingsExpander
+    /// Positional: glyph, header, description, content
+    public convenience init(_ headerIconGlyph: String, _ header: String, _ description: String? = nil, _ content: FrameworkElement? = nil, _ actionIcon: FontIcon? = nil) {
+        self.init(headerIconGlyph: headerIconGlyph, header: header, description: description, content: content, actionIcon: actionIcon)
+    }
+
+    /// Positional: header, description (FrameworkElement)
+    public convenience init(_ header: String, _ description: FrameworkElement? = nil) {
+        self.init(header: header, description: description, content: nil)
+    }
+
+    // MARK: - Internal helpers for SettingsExpander
+
+    /// Suppresses the card border/background for use as an inner item inside SettingsExpander.
     func suppressCardStyling() {
         cardBorder.background = nil
         cardBorder.borderBrush = nil
@@ -90,38 +164,93 @@ public class SettingsCard: ButtonBase {
         cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0)
     }
 
-    private func build(headerIcon: IconElement? = nil, header: String, description: FrameworkElement, content: FrameworkElement? = nil, actionIcon: FontIcon? = nil) -> WinUI.Grid {
+    /// Applies the item padding used when hosted inside a SettingsExpander.
+    func applyExpanderItemPadding() {
+        // Left = 58 (aligns with header icon column), right = 44 (leaves room for action icon)
+        cardBorder.padding = WinUI.Thickness(left: 58, top: 8, right: 44, bottom: 8)
+    }
+
+    // MARK: - State management
+
+    private func onIsClickEnabledChanged() {
+        updateActionIconVisibility()
+        if isClickEnabled {
+            enableHoverInteraction()
+        } else {
+            disableHoverInteraction()
+        }
+    }
+
+    private func updateActionIconVisibility() {
+        guard let holder = actionIconHolder else { return }
+        holder.visibility = (isClickEnabled && isActionIconVisible) ? .visible : .collapsed
+    }
+
+    private func enableHoverInteraction() {
+        disableHoverInteraction()
         let isDark = App.context.theme.isDark
-        let secondaryForeground = WinUI.SolidColorBrush(isDark
-            ? UWP.Color(a: 255, r: 169, g: 173, b: 189)
-            : UWP.Color(a: 255, r: 96, g: 104, b: 112))
+        pointerEntered.addHandler { [weak self] _, _ in
+            self?.cardBorder.background = cardHoverBrush(isDark: isDark)
+        }
+        pointerExited.addHandler { [weak self] _, _ in
+            self?.cardBorder.background = cardBackgroundBrush(isDark: isDark)
+        }
+        pointerPressed.addHandler { [weak self] _, _ in
+            self?.cardBorder.background = cardPressedBrush(isDark: isDark)
+        }
+        pointerReleased.addHandler { [weak self] _, _ in
+            self?.cardBorder.background = cardBackgroundBrush(isDark: isDark)
+        }
+    }
+
+    private func disableHoverInteraction() {
+        // WinUI event tokens are not easily removable without storing them;
+        // reassign background to reset visual state.
+        let isDark = App.context.theme.isDark
+        cardBorder.background = cardBackgroundBrush(isDark: isDark)
+    }
+
+    // MARK: - Layout builder
+
+    private func buildLayout(
+        headerIcon: IconElement? = nil,
+        header: String? = nil,
+        description: FrameworkElement? = nil,
+        content: FrameworkElement? = nil,
+        actionIcon: FontIcon? = nil
+    ) -> WinUI.Grid {
+        let isDark = App.context.theme.isDark
+        let secondaryForeground = secondaryBrush(isDark: isDark)
 
         let container = WinUI.Grid()
 
-        let iconColumn = WinUI.ColumnDefinition()
-        iconColumn.width = WinUI.GridLength(value: 40, gridUnitType: .pixel)
-        container.columnDefinitions.append(iconColumn)
+        // Columns: [icon] [text*] [content auto] [actionIcon auto]
+        let iconCol = WinUI.ColumnDefinition()
+        iconCol.width = WinUI.GridLength(value: headerIcon != nil ? 40 : 0, gridUnitType: .pixel)
+        container.columnDefinitions.append(iconCol)
 
-        let textColumn = WinUI.ColumnDefinition()
-        textColumn.width = WinUI.GridLength(value: 1, gridUnitType: .star)
-        container.columnDefinitions.append(textColumn)
+        let textCol = WinUI.ColumnDefinition()
+        textCol.width = WinUI.GridLength(value: 1, gridUnitType: .star)
+        container.columnDefinitions.append(textCol)
 
-        let controlColumn = WinUI.ColumnDefinition()
-        controlColumn.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
-        container.columnDefinitions.append(controlColumn)
+        let contentCol = WinUI.ColumnDefinition()
+        contentCol.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
+        container.columnDefinitions.append(contentCol)
 
-        let actionIconColumn = WinUI.ColumnDefinition()
-        actionIconColumn.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
-        container.columnDefinitions.append(actionIconColumn)
+        let actionCol = WinUI.ColumnDefinition()
+        actionCol.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
+        container.columnDefinitions.append(actionCol)
 
-        let titleRow = WinUI.RowDefinition()
-        titleRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
-        container.rowDefinitions.append(titleRow)
+        // Rows: [header auto] [description auto]
+        let headerRow = WinUI.RowDefinition()
+        headerRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
+        container.rowDefinitions.append(headerRow)
 
         let descRow = WinUI.RowDefinition()
         descRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
         container.rowDefinitions.append(descRow)
 
+        // Header icon (col 0, spans both rows)
         if let icon = headerIcon {
             if let fontIcon = icon as? WinUI.FontIcon {
                 fontIcon.fontSize = 20
@@ -129,50 +258,136 @@ public class SettingsCard: ButtonBase {
                 imageIcon.width = 24
                 imageIcon.height = 24
             }
-
+            icon.verticalAlignment = .center
             container.children.append(icon)
             try? WinUI.Grid.setRow(icon, 0)
             try? WinUI.Grid.setColumn(icon, 0)
             try? WinUI.Grid.setRowSpan(icon, 2)
         }
 
-        let titleLabel = WinUI.TextBlock()
-        titleLabel.text = header
-        titleLabel.fontSize = 14
-        titleLabel.margin = WinUI.Thickness(left: 16, top: 0, right: 0, bottom: 2)
-        container.children.append(titleLabel)
-        try? WinUI.Grid.setRow(titleLabel, 0)
-        try? WinUI.Grid.setColumn(titleLabel, 1)
-
-        if let description = description as? TextBlock {
-            description.foreground = secondaryForeground
-            description.fontSize = 12
-            description.margin = WinUI.Thickness(left: 16, top: 0, right: 0, bottom: 0)
-            description.textWrapping = .wrap
-        } else {
-            description.margin = Thickness(left: 4, top: 0, right: 0, bottom: 0)
-        }
-        container.children.append(description)
-        try? WinUI.Grid.setRow(description, 1)
-        try? WinUI.Grid.setColumn(description, 1)
-
-        if let content {
-            content.verticalAlignment = .center
-            container.children.append(content)
-            try? WinUI.Grid.setRow(content, 0)
-            try? WinUI.Grid.setColumn(content, 2)
-            try? WinUI.Grid.setRowSpan(content, 2)
+        // Header label (col 1, row 0)
+        if let headerText = header, !headerText.isEmpty {
+            let titleLabel = WinUI.TextBlock()
+            titleLabel.text = headerText
+            titleLabel.fontSize = 14
+            titleLabel.textWrapping = .wrap
+            titleLabel.margin = WinUI.Thickness(left: headerIcon != nil ? 16 : 0, top: 0, right: 0, bottom: 2)
+            container.children.append(titleLabel)
+            try? WinUI.Grid.setRow(titleLabel, 0)
+            try? WinUI.Grid.setColumn(titleLabel, 1)
         }
 
-        if let actionIcon = actionIcon {
-            actionIcon.fontSize = 16
-            actionIcon.margin = WinUI.Thickness(left: 16, top: 0, right: 8, bottom: 0)
-            container.children.append(actionIcon)
-            try? WinUI.Grid.setRow(actionIcon, 0)
-            try? WinUI.Grid.setColumn(actionIcon, 3)
-            try? WinUI.Grid.setRowSpan(actionIcon, 2)
+        // Description (col 1, row 1)
+        if let desc = description {
+            if let tb = desc as? TextBlock {
+                tb.foreground = secondaryForeground
+                tb.fontSize = 12
+                tb.textWrapping = .wrap
+                tb.margin = WinUI.Thickness(left: headerIcon != nil ? 16 : 0, top: 0, right: 0, bottom: 0)
+            } else {
+                desc.margin = WinUI.Thickness(left: headerIcon != nil ? 16 : 0, top: 0, right: 0, bottom: 0)
+            }
+            container.children.append(desc)
+            try? WinUI.Grid.setRow(desc, 1)
+            try? WinUI.Grid.setColumn(desc, 1)
         }
 
+        // Right-side content (col 2, spans both rows) — only shown in .right alignment
+        if let ctrl = content, contentAlignment == .right {
+            ctrl.verticalAlignment = .center
+            container.children.append(ctrl)
+            try? WinUI.Grid.setRow(ctrl, 0)
+            try? WinUI.Grid.setColumn(ctrl, 2)
+            try? WinUI.Grid.setRowSpan(ctrl, 2)
+        }
+
+        // Action icon (col 3, spans both rows) — only when isClickEnabled && isActionIconVisible
+        let effectiveActionIcon = actionIcon ?? self.actionIcon
+        if let aIcon = effectiveActionIcon {
+            aIcon.fontSize = 13
+            aIcon.margin = WinUI.Thickness(left: 14, top: 0, right: 0, bottom: 0)
+            aIcon.verticalAlignment = .center
+            if let toolTip = actionIconToolTip {
+                // ToolTipService not directly available in this API; store for future use
+                _ = toolTip
+            }
+            aIcon.visibility = (isClickEnabled && isActionIconVisible) ? .visible : .collapsed
+            container.children.append(aIcon)
+            try? WinUI.Grid.setRow(aIcon, 0)
+            try? WinUI.Grid.setColumn(aIcon, 3)
+            try? WinUI.Grid.setRowSpan(aIcon, 2)
+            actionIconHolder = aIcon
+        }
+
+        rootGrid = container
         return container
     }
+
+    // MARK: - Helpers
+
+    private func makeDescriptionView(_ text: String?) -> FrameworkElement? {
+        guard let text, !text.isEmpty else { return nil }
+        let tb: TextBlock = (try? XamlReader.load("""
+            <TextBlock xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" >
+            \(text)
+            </TextBlock>
+            """)) as? TextBlock ?? {
+            let t = TextBlock()
+            t.text = text
+            return t
+        }()
+        return tb
+    }
+}
+
+// MARK: - Brushes (internal)
+
+func cardBackgroundBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(
+        isDark
+            ? UWP.Color(a: 255, r: 32, g: 36, b: 44)
+            : UWP.Color(a: 255, r: 255, g: 255, b: 255)
+    )
+}
+
+func cardBorderBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(
+        isDark
+            ? UWP.Color(a: 255, r: 49, g: 55, b: 66)
+            : UWP.Color(a: 255, r: 229, g: 231, b: 235)
+    )
+}
+
+private func cardHoverBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+    // ControlFillColorSecondary
+    WinUI.SolidColorBrush(
+        isDark
+            ? UWP.Color(a: 255, r: 40, g: 44, b: 53)
+            : UWP.Color(a: 255, r: 246, g: 246, b: 248)
+    )
+}
+
+private func cardPressedBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+    // ControlFillColorTertiary
+    WinUI.SolidColorBrush(
+        isDark
+            ? UWP.Color(a: 255, r: 28, g: 32, b: 40)
+            : UWP.Color(a: 255, r: 240, g: 240, b: 242)
+    )
+}
+
+func dividerBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(
+        isDark
+            ? UWP.Color(a: 255, r: 58, g: 63, b: 77)
+            : UWP.Color(a: 255, r: 230, g: 232, b: 236)
+    )
+}
+
+func secondaryBrush(isDark: Bool) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(
+        isDark
+            ? UWP.Color(a: 255, r: 174, g: 178, b: 190)
+            : UWP.Color(a: 255, r: 96, g: 104, b: 112)
+    )
 }

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -179,8 +179,9 @@ public class SettingsCard: ButtonBase {
 
     /// Applies the item padding used when hosted inside a SettingsExpander.
     func applyExpanderItemPadding() {
-        // Left = 58 (aligns with header icon column), right = 44 (leaves room for action icon)
-        cardBorder.padding = WinUI.Thickness(left: 58, top: 8, right: 44, bottom: 8)
+        // Clickable items: right=16 (no action icon space); others: right=44
+        let rightPadding: Double = isClickEnabled ? 16 : 44
+        cardBorder.padding = WinUI.Thickness(left: 58, top: 8, right: rightPadding, bottom: 8)
     }
 
     // MARK: - State management

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -157,7 +157,7 @@ public class SettingsExpander: StackPanel {
 
         // Items
         let effectiveItems = itemsSource ?? items
-        for (index, item) in effectiveItems.enumerated() {
+        for item in effectiveItems {
             item.suppressCardStyling()
             item.applyExpanderItemPadding()
             // Top border only (0,1,0,0) to match WCTK item separator style

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -3,88 +3,189 @@ import WinUI
 import WindowsFoundation
 
 public class SettingsExpander: StackPanel {
-    var isExpanded = false
-    var isAnimating = false
 
-    let chevron = ChevronIcon(glyph: "\u{E70D}", expandAngle: 180)
-    let expandedHost = {
+    // MARK: - Public properties
+
+    public var expanded: (() -> Void)?
+    public var collapsed: (() -> Void)?
+
+    public var itemsHeader: WinUI.UIElement? {
+        didSet { rebuildItems() }
+    }
+    public var itemsFooter: WinUI.UIElement? {
+        didSet { rebuildItems() }
+    }
+    public var itemsSource: [SettingsCard]? {
+        didSet { rebuildItems() }
+    }
+
+    public var isExpanded: Bool = false {
+        didSet {
+            guard isExpanded != oldValue else { return }
+            runExpandCollapseAnimation(expanding: isExpanded)
+        }
+    }
+
+    // MARK: - Private state
+
+    private var isAnimating = false
+    private let chevron = ChevronIcon(glyph: "\u{E70D}", expandAngle: 180)
+    private let expandedHost: WinUI.StackPanel = {
         let host = WinUI.StackPanel()
-        // host.orientation = .vertical
-        // host.spacing = 0
         host.visibility = .collapsed
         host.opacity = 0
         return host
     }()
-    let expandedTransform = {
-        let transform = WinUI.CompositeTransform()
-        transform.translateY = -8
-        return transform
+    private let expandedTransform: WinUI.CompositeTransform = {
+        let t = WinUI.CompositeTransform()
+        t.translateY = -8
+        return t
     }()
 
+    private var items: [SettingsCard] = []
+
+    // MARK: - Init
+
     public init(
-        _ headerIconPath: String,
-        _ header: String,
-        _ description: String,
-        _ content: String,
-        _ items: [SettingsCard]
+        headerIconGlyph: String,
+        header: String,
+        description: String? = nil,
+        content: FrameworkElement? = nil,
+        items: [SettingsCard] = []
     ) {
         super.init()
+        self.items = items
+        setup(
+            headerCard: SettingsCard(
+                headerIconGlyph: headerIconGlyph,
+                header: header,
+                description: description,
+                content: content,
+                actionIcon: chevron
+            )
+        )
+    }
 
+    /// Positional: iconPath, header, description, contentText, items
+    public convenience init(_ headerIconPath: String, _ header: String, _ description: String? = nil, _ contentText: String? = nil, _ items: [SettingsCard] = []) {
+        self.init(headerIconPath: headerIconPath, header: header, description: description, contentText: contentText, items: items)
+    }
+
+    public init(
+        headerIconPath: String,
+        header: String,
+        description: String? = nil,
+        contentText: String? = nil,
+        items: [SettingsCard] = []
+    ) {
+        super.init()
+        self.items = items
+        setup(
+            headerCard: SettingsCard(
+                headerIconPath: headerIconPath,
+                header: header,
+                description: description,
+                contentText: contentText,
+                actionIcon: chevron
+            )
+        )
+    }
+
+    public init(
+        header: String,
+        description: FrameworkElement? = nil,
+        content: FrameworkElement? = nil,
+        items: [SettingsCard] = []
+    ) {
+        super.init()
+        self.items = items
+        setup(
+            headerCard: SettingsCard(
+                header: header,
+                description: description,
+                content: content,
+                actionIcon: chevron
+            )
+        )
+    }
+
+    // MARK: - Setup
+
+    private func setup(headerCard: SettingsCard) {
         let isDark = App.context.theme.isDark
 
-        // Header card with card styling suppressed — outer card provides the border
-        let card = SettingsCard(headerIconPath, header, description, content, chevron)
-        card.isClickEnabled = true
-        card.suppressCardStyling()
-        card.click.addHandler { [weak self] _, _ in
+        headerCard.isClickEnabled = true
+        headerCard.suppressCardStyling()
+        headerCard.isActionIconVisible = true
+        headerCard.click.addHandler { [weak self] _, _ in
             guard let self else { return }
-            self.runExpandCollapseAnimation(expanding: !self.isExpanded)
+            self.isExpanded = !self.isExpanded
         }
 
         expandedHost.renderTransform = expandedTransform
+        buildExpandedContent(isDark: isDark)
 
-        // Divider between header and expanded items
-        let topDivider = WinUI.Border()
-        topDivider.height = 1
-        topDivider.margin = WinUI.Thickness(left: 16, top: 0, right: 16, bottom: 0)
-        topDivider.background = dividerBrush(isDark: isDark)
-        expandedHost.children.append(topDivider)
+        let cardStack = WinUI.StackPanel()
+        cardStack.orientation = .vertical
+        cardStack.spacing = 0
+        cardStack.children.append(headerCard)
+        cardStack.children.append(expandedHost)
 
-        for (index, item) in items.enumerated() {
-            if index > 0 {
-                let divider = WinUI.Border()
-                divider.height = 1
-                divider.margin = WinUI.Thickness(left: 16, top: 0, right: 16, bottom: 0)
-                divider.background = dividerBrush(isDark: isDark)
-                expandedHost.children.append(divider)
-            }
-            item.suppressCardStyling()
-            expandedHost.children.append(item)
-        }
-
-        // One outer card container wrapping both header and expanded items
         let outerCard = WinUI.Border()
         outerCard.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
         outerCard.background = cardBackgroundBrush(isDark: isDark)
         outerCard.borderBrush = cardBorderBrush(isDark: isDark)
         outerCard.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
-
-        let cardStack = WinUI.StackPanel()
-        cardStack.orientation = .vertical
-        cardStack.spacing = 0
-        cardStack.children.append(card)
-        cardStack.children.append(expandedHost)
-
         outerCard.child = cardStack
+
         self.children.append(outerCard)
     }
 
-    private func makeDuration(milliseconds: Int64) -> Duration {
-        Duration(
-            timeSpan: TimeSpan(duration: milliseconds * 10_000),
-            type: .timeSpan
-        )
+    private func buildExpandedContent(isDark: Bool) {
+        // Clear existing children (keep transform)
+        while expandedHost.children.count > 0 {
+            expandedHost.children.removeAt(0)
+        }
+
+        // ItemsHeader
+        if let header = itemsHeader {
+            expandedHost.children.append(header)
+        }
+
+        // Top divider
+        expandedHost.children.append(makeDivider(isDark: isDark))
+
+        // Items
+        let effectiveItems = itemsSource ?? items
+        for (index, item) in effectiveItems.enumerated() {
+            if index > 0 {
+                expandedHost.children.append(makeDivider(isDark: isDark))
+            }
+            item.suppressCardStyling()
+            item.applyExpanderItemPadding()
+            expandedHost.children.append(item)
+        }
+
+        // ItemsFooter
+        if let footer = itemsFooter {
+            expandedHost.children.append(footer)
+        }
     }
+
+    private func rebuildItems() {
+        let isDark = App.context.theme.isDark
+        buildExpandedContent(isDark: isDark)
+    }
+
+    private func makeDivider(isDark: Bool) -> WinUI.Border {
+        let divider = WinUI.Border()
+        divider.height = 1
+        divider.margin = WinUI.Thickness(left: 16, top: 0, right: 16, bottom: 0)
+        divider.background = dividerBrush(isDark: isDark)
+        return divider
+    }
+
+    // MARK: - Animation
 
     private func runExpandCollapseAnimation(expanding: Bool) {
         guard !isAnimating else { return }
@@ -98,308 +199,50 @@ public class SettingsExpander: StackPanel {
 
         let storyboard = WinUI.Storyboard()
 
-        let opacityAnimation = WinUI.DoubleAnimation()
-        opacityAnimation.from = expanding ? 0 : 1
-        opacityAnimation.to = expanding ? 1 : 0
-        opacityAnimation.duration = makeDuration(milliseconds: 180)
+        let opacityAnim = WinUI.DoubleAnimation()
+        opacityAnim.from = expanding ? 0 : 1
+        opacityAnim.to = expanding ? 1 : 0
+        opacityAnim.duration = makeDuration(milliseconds: 180)
 
-        let translateAnimation = WinUI.DoubleAnimation()
-        translateAnimation.from = expanding ? -8 : 0
-        translateAnimation.to = expanding ? 0 : -8
-        translateAnimation.duration = makeDuration(milliseconds: 180)
+        let translateAnim = WinUI.DoubleAnimation()
+        translateAnim.from = expanding ? -8 : 0
+        translateAnim.to = expanding ? 0 : -8
+        translateAnim.duration = makeDuration(milliseconds: 180)
 
         let easing = WinUI.CubicEase()
         easing.easingMode = .easeOut
-        opacityAnimation.easingFunction = easing
-        translateAnimation.easingFunction = easing
+        opacityAnim.easingFunction = easing
+        translateAnim.easingFunction = easing
 
-        try? WinUI.Storyboard.setTarget(opacityAnimation, expandedHost)
-        try? WinUI.Storyboard.setTargetProperty(opacityAnimation, "Opacity")
+        try? WinUI.Storyboard.setTarget(opacityAnim, expandedHost)
+        try? WinUI.Storyboard.setTargetProperty(opacityAnim, "Opacity")
+        try? WinUI.Storyboard.setTarget(translateAnim, expandedTransform)
+        try? WinUI.Storyboard.setTargetProperty(translateAnim, "TranslateY")
 
-        try? WinUI.Storyboard.setTarget(translateAnimation, expandedTransform)
-        try? WinUI.Storyboard.setTargetProperty(translateAnimation, "TranslateY")
+        storyboard.children.append(opacityAnim)
+        storyboard.children.append(translateAnim)
 
-        storyboard.children.append(opacityAnimation)
-        storyboard.children.append(translateAnimation)
-
-        storyboard.completed.addHandler { _, _ in
+        storyboard.completed.addHandler { [weak self] _, _ in
+            guard let self else { return }
             if !expanding {
                 self.expandedHost.visibility = .collapsed
             }
-
-            self.isExpanded = expanding
             self.isAnimating = false
+            if expanding {
+                self.expanded?()
+            } else {
+                self.collapsed?()
+            }
         }
 
         expanding ? chevron.expand() : chevron.collapse()
-
         try? storyboard.begin()
     }
-}
 
-func buildSettingsExpanderCard(
-    iconGlyph: String,
-    title: String,
-    description: String,
-    trailingText: String? = nil,
-    expandedContent: WinUI.UIElement,
-    showsOuterCard: Bool = true
-) -> WinUI.UIElement {
-    let isDark = App.context.theme.isDark
-
-    let root = WinUI.StackPanel()
-    root.orientation = .vertical
-    root.spacing = 0
-
-    let cardStack = WinUI.StackPanel()
-    cardStack.orientation = .vertical
-    cardStack.spacing = 0
-
-    // ===== 头部 =====
-    let headerBorder = WinUI.Border()
-    headerBorder.padding = WinUI.Thickness(left: 16, top: 14, right: 16, bottom: 14)
-
-    let headerGrid = WinUI.Grid()
-
-    let iconColumn = WinUI.ColumnDefinition()
-    iconColumn.width = WinUI.GridLength(value: 56, gridUnitType: .pixel)
-    headerGrid.columnDefinitions.append(iconColumn)
-
-    let textColumn = WinUI.ColumnDefinition()
-    textColumn.width = WinUI.GridLength(value: 1, gridUnitType: .star)
-    headerGrid.columnDefinitions.append(textColumn)
-
-    let trailingColumn = WinUI.ColumnDefinition()
-    trailingColumn.width = WinUI.GridLength(value: 1, gridUnitType: .auto)
-    headerGrid.columnDefinitions.append(trailingColumn)
-
-    let titleRow = WinUI.RowDefinition()
-    titleRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
-    headerGrid.rowDefinitions.append(titleRow)
-
-    let descRow = WinUI.RowDefinition()
-    descRow.height = WinUI.GridLength(value: 1, gridUnitType: .auto)
-    headerGrid.rowDefinitions.append(descRow)
-
-    let iconBadge = WinUI.Border()
-    iconBadge.width = 40
-    iconBadge.height = 40
-    iconBadge.cornerRadius = WinUI.CornerRadius(topLeft: 12, topRight: 12, bottomRight: 12, bottomLeft: 12)
-    iconBadge.background = accentFillBrush(isDark: isDark)
-    iconBadge.verticalAlignment = .center
-    iconBadge.horizontalAlignment = .center
-
-    let icon = WinUI.FontIcon()
-    icon.glyph = iconGlyph
-    icon.fontSize = 18
-    icon.foreground = WinUI.SolidColorBrush(UWP.Color(a: 255, r: 255, g: 255, b: 255))
-    iconBadge.child = icon
-
-    headerGrid.children.append(iconBadge)
-    try? WinUI.Grid.setColumn(iconBadge, 0)
-    try? WinUI.Grid.setRow(iconBadge, 0)
-    try? WinUI.Grid.setRowSpan(iconBadge, 2)
-
-    let titleLabel = WinUI.TextBlock()
-    titleLabel.text = title
-    titleLabel.fontSize = 16
-    titleLabel.fontWeight = UWP.FontWeights.semiBold
-    titleLabel.foreground = primaryBrush(isDark: isDark)
-    titleLabel.margin = WinUI.Thickness(left: 12, top: 1, right: 12, bottom: 4)
-    headerGrid.children.append(titleLabel)
-    try? WinUI.Grid.setColumn(titleLabel, 1)
-    try? WinUI.Grid.setRow(titleLabel, 0)
-
-    let descLabel = WinUI.TextBlock()
-    descLabel.text = description
-    descLabel.fontSize = 13
-    descLabel.textWrapping = .wrap
-    descLabel.foreground = secondaryBrush(isDark: isDark)
-    descLabel.margin = WinUI.Thickness(left: 12, top: 0, right: 12, bottom: 0)
-    headerGrid.children.append(descLabel)
-    try? WinUI.Grid.setColumn(descLabel, 1)
-    try? WinUI.Grid.setRow(descLabel, 1)
-
-    let trailingHost = WinUI.StackPanel()
-    trailingHost.orientation = .horizontal
-    trailingHost.spacing = 8
-    trailingHost.verticalAlignment = .center
-    trailingHost.horizontalAlignment = .right
-
-    if let trailingText, !trailingText.isEmpty {
-        let trailingLabel = WinUI.TextBlock()
-        trailingLabel.text = trailingText
-        trailingLabel.fontSize = 13
-        trailingLabel.foreground = secondaryBrush(isDark: isDark)
-        trailingLabel.verticalAlignment = .center
-        trailingHost.children.append(trailingLabel)
-    }
-
-    let chevron = WinUI.FontIcon()
-    chevron.glyph = "\u{E70D}"
-    chevron.fontSize = 12
-    chevron.foreground = secondaryBrush(isDark: isDark)
-    chevron.verticalAlignment = .center
-    trailingHost.children.append(chevron)
-
-    headerGrid.children.append(trailingHost)
-    try? WinUI.Grid.setColumn(trailingHost, 2)
-    try? WinUI.Grid.setRow(trailingHost, 0)
-    try? WinUI.Grid.setRowSpan(trailingHost, 2)
-
-    headerBorder.child = headerGrid
-    cardStack.children.append(headerBorder)
-
-    // ===== 展开区 =====
-    let expandedHost = WinUI.StackPanel()
-    expandedHost.orientation = .vertical
-    expandedHost.spacing = 0
-    expandedHost.visibility = .collapsed
-    expandedHost.opacity = 0
-
-    let expandedTransform = WinUI.CompositeTransform()
-    expandedTransform.translateY = -8
-    expandedHost.renderTransform = expandedTransform
-
-    var isExpanded = false
-    var isAnimating = false
-
-    let divider = WinUI.Border()
-    divider.height = 1
-    divider.margin = WinUI.Thickness(left: 16, top: 0, right: 16, bottom: 0)
-    divider.background = dividerBrush(isDark: isDark)
-    expandedHost.children.append(divider)
-
-    let contentContainer = WinUI.Border()
-    contentContainer.padding = WinUI.Thickness(left: 16, top: 16, right: 16, bottom: 16)
-    contentContainer.child = expandedContent
-    expandedHost.children.append(contentContainer)
-
-    cardStack.children.append(expandedHost)
-
-    if showsOuterCard {
-        let card = WinUI.Border()
-        card.cornerRadius = WinUI.CornerRadius(topLeft: 12, topRight: 12, bottomRight: 12, bottomLeft: 12)
-        card.background = cardBackgroundBrush(isDark: isDark)
-        card.borderBrush = cardBorderBrush(isDark: isDark)
-        card.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
-        card.child = cardStack
-        root.children.append(card)
-    } else {
-        root.children.append(cardStack)
-    }
-
-    func makeDuration(milliseconds: Int64) -> WinUI.Duration {
+    private func makeDuration(milliseconds: Int64) -> WinUI.Duration {
         WinUI.Duration(
             timeSpan: WindowsFoundation.TimeSpan(duration: milliseconds * 10_000),
             type: .timeSpan
         )
     }
-
-    func runExpandCollapseAnimation(expanding: Bool) {
-        guard !isAnimating else { return }
-        isAnimating = true
-
-        if expanding {
-            expandedHost.visibility = .visible
-            expandedHost.opacity = 0
-            expandedTransform.translateY = -8
-        }
-
-        let storyboard = WinUI.Storyboard()
-
-        let opacityAnimation = WinUI.DoubleAnimation()
-        opacityAnimation.from = expanding ? 0 : 1
-        opacityAnimation.to = expanding ? 1 : 0
-        opacityAnimation.duration = makeDuration(milliseconds: 180)
-
-        let translateAnimation = WinUI.DoubleAnimation()
-        translateAnimation.from = expanding ? -8 : 0
-        translateAnimation.to = expanding ? 0 : -8
-        translateAnimation.duration = makeDuration(milliseconds: 180)
-
-        let easing = WinUI.CubicEase()
-        easing.easingMode = .easeOut
-        opacityAnimation.easingFunction = easing
-        translateAnimation.easingFunction = easing
-
-        try? WinUI.Storyboard.setTarget(opacityAnimation, expandedHost)
-        try? WinUI.Storyboard.setTargetProperty(opacityAnimation, "Opacity")
-
-        try? WinUI.Storyboard.setTarget(translateAnimation, expandedTransform)
-        try? WinUI.Storyboard.setTargetProperty(translateAnimation, "TranslateY")
-
-        storyboard.children.append(opacityAnimation)
-        storyboard.children.append(translateAnimation)
-
-        storyboard.completed.addHandler { _, _ in
-            if !expanding {
-                expandedHost.visibility = .collapsed
-            }
-
-            isExpanded = expanding
-            isAnimating = false
-        }
-
-        chevron.glyph = expanding ? "\u{E70E}" : "\u{E70D}"
-
-        try? storyboard.begin()
-    }
-
-    headerBorder.pointerPressed.addHandler { _, e in
-        runExpandCollapseAnimation(expanding: !isExpanded)
-        e?.handled = true
-    }
-
-    return root
-}
-
-// MARK: - 卡片画刷
-
-private func primaryBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 243, g: 244, b: 246)
-            : UWP.Color(a: 255, r: 28, g: 30, b: 33)
-    )
-}
-
-private func secondaryBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 174, g: 178, b: 190)
-            : UWP.Color(a: 255, r: 96, g: 104, b: 112)
-    )
-}
-
-private func dividerBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 58, g: 63, b: 77)
-            : UWP.Color(a: 255, r: 230, g: 232, b: 236)
-    )
-}
-
-func cardBackgroundBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 32, g: 36, b: 44)
-            : UWP.Color(a: 255, r: 255, g: 255, b: 255)
-    )
-}
-
-func cardBorderBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 49, g: 55, b: 66)
-            : UWP.Color(a: 255, r: 229, g: 231, b: 235)
-    )
-}
-
-private func accentFillBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 103, g: 122, b: 255)
-            : UWP.Color(a: 255, r: 90, g: 104, b: 255)
-    )
 }

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -158,11 +158,11 @@ public class SettingsExpander: StackPanel {
         // Items
         let effectiveItems = itemsSource ?? items
         for (index, item) in effectiveItems.enumerated() {
-            if index > 0 {
-                expandedHost.children.append(makeDivider(isDark: isDark))
-            }
             item.suppressCardStyling()
             item.applyExpanderItemPadding()
+            // Top border only (0,1,0,0) to match WCTK item separator style
+            item.cardBorder.borderThickness = WinUI.Thickness(left: 0, top: 1, right: 0, bottom: 0)
+            item.cardBorder.borderBrush = dividerBrush(isDark: isDark)
             expandedHost.children.append(item)
         }
 
@@ -199,18 +199,22 @@ public class SettingsExpander: StackPanel {
 
         let storyboard = WinUI.Storyboard()
 
+        // Expand: 333ms with decelerate (0,0,0,1); Collapse: 167ms with accelerate (1,1,0,1)
+        let duration = expanding ? 333 : 167
+        let easingMode: WinUI.EasingMode = expanding ? .easeOut : .easeIn
+
         let opacityAnim = WinUI.DoubleAnimation()
         opacityAnim.from = expanding ? 0 : 1
         opacityAnim.to = expanding ? 1 : 0
-        opacityAnim.duration = makeDuration(milliseconds: 180)
+        opacityAnim.duration = makeDuration(milliseconds: Int64(duration))
 
         let translateAnim = WinUI.DoubleAnimation()
         translateAnim.from = expanding ? -8 : 0
         translateAnim.to = expanding ? 0 : -8
-        translateAnim.duration = makeDuration(milliseconds: 180)
+        translateAnim.duration = makeDuration(milliseconds: Int64(duration))
 
         let easing = WinUI.CubicEase()
-        easing.easingMode = .easeOut
+        easing.easingMode = easingMode
         opacityAnim.easingFunction = easing
         translateAnim.easingFunction = easing
 


### PR DESCRIPTION
## 向着 WCTK SettingsCard | SettingsExpander 前进

## 分析

<img width="1878" height="720" alt="image" src="https://github.com/user-attachments/assets/bd82d3b9-5831-4925-af8e-c09c66bffba2" />

这是我依据 WTCK 开源社区代码画出来的布局图。可以看到，其Template是一个Grid布局。分别有 HeaderIocnPresenter [HeaderPresenter 和 DescPresenter] 组成的 StackPanel、ContentPresenter 和占据两行的 ActionIcon。

1. 占据两行 ActionIcon，其占据两行的原因是需要对齐到中间。aciontIcon的作用是，在卡片可以点击的时候，放置一个图标，告知用户可以点击。在Ruslan项目中有打开外部链接和展开两种，用更为常见和已经编写好的展开图标作为默认的ActionIcon。
2. contentPresenter是存放各种调整组件的部分，随着模式的不同会有不同的摆放方式。跟随 ContentAlignment  left right vertical 的不同模式， content 会被放置到，单独的一列（其他所有组件都不显示）、普通状态（即上图）、 vertical模式（和stackpanel，放置到同一列上，即 row=1，col=1的位置上）。

## 实现

我按照上面的布局，在border内部实现了SettingsCard，对比 WCTK 中还没有实现的点如下：
1. isEnabled = false 并没有改变card内容的样式，而WCTK是会将内部组件，比如蓝色的按钮修改样式，文字变为灰色。
2. 没有实现 ActionToolTip
3. 实际上实现的SettingsCard的颜色和WCTK是不一样的，但是我认为原本的颜色更加符合整体软件的颜色，所以没做修改。
4. 上文提到的contentPresenter的 vertical 模式，WCTK实现的版本其实是会根据content的内容大小做出改变的。

对比前一版本的SettingCard，增加了鼠标悬浮事件，改变样式，对齐了布局方式，修改的展开的动画和WCTK一致。

## 效果

<img width="2604" height="1703" alt="动画" src="https://github.com/user-attachments/assets/e09b57ed-826e-4136-a1d3-d514d0b892ef" />


