### PR TITLE
Controls/about settings

### DIFF
--- a/Sources/RsUI/Controls/SettingsBrushes.swift
+++ b/Sources/RsUI/Controls/SettingsBrushes.swift
@@ -1,0 +1,123 @@
+import UWP
+import WinUI
+
+
+// MARK: - Brushes (internal)
+
+enum SettingsBrushMode {
+    case light
+    case dark
+    case automatic
+
+    init(theme: AppTheme) {
+        switch theme {
+        case .light:
+            self = .light
+        case .dark:
+            self = .dark
+        case .auto:
+            self = .automatic
+        }
+    }
+}
+
+private struct SettingsBrushPalette {
+    let settingsCardBackground: UWP.Color
+    let settingsCardBackgroundPointerOver: UWP.Color
+    let settingsCardBackgroundPressed: UWP.Color
+    let settingsCardBackgroundDisabled: UWP.Color
+
+    let settingsCardForeground: UWP.Color
+    let settingsCardForegroundPointerOver: UWP.Color
+    let settingsCardForegroundPressed: UWP.Color
+    let settingsCardForegroundDisabled: UWP.Color
+
+    let settingsCardBorderBrush: UWP.Color
+    let settingsCardBorderBrushPointerOver: UWP.Color
+    let settingsCardBorderBrushPressed: UWP.Color
+    let settingsCardBorderBrushDisabled: UWP.Color
+
+    let divider: UWP.Color
+    let secondary: UWP.Color
+
+    static let light = SettingsBrushPalette(
+        settingsCardBackground: UWP.Color(a: 0xB3, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardBackgroundPointerOver: UWP.Color(a: 0x80, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardBackgroundPressed: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardBackgroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+
+        settingsCardForeground: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForegroundPointerOver: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForegroundPressed: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForegroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+
+        settingsCardBorderBrush: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushPointerOver: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushPressed: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushDisabled: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+
+        divider: UWP.Color(a: 15, r: 0, g: 0, b: 0),
+        secondary: UWP.Color(a: 255, r: 96, g: 104, b: 112)
+    )
+
+    static let dark = SettingsBrushPalette(
+        settingsCardBackground: UWP.Color(a: 0x0D, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardBackgroundPointerOver: UWP.Color(a: 0x15, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardBackgroundPressed: UWP.Color(a: 0x08, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardBackgroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+
+        settingsCardForeground: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForegroundPointerOver: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForegroundPressed: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForegroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+
+        settingsCardBorderBrush: UWP.Color(a: 25, r: 255, g: 255, b: 255),
+        settingsCardBorderBrushPointerOver: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushPressed: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushDisabled: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+
+        divider: UWP.Color(a: 24, r: 255, g: 255, b: 255),
+        secondary: UWP.Color(a: 255, r: 174, g: 178, b: 190)
+    )
+
+    static let automatic = dark
+}
+
+private func settingsBrushPalette(for mode: SettingsBrushMode) -> SettingsBrushPalette {
+    switch mode {
+    case .light:
+        return .light
+    case .dark:
+        return .dark
+    case .automatic:
+        return .automatic
+    }
+}
+
+private func settingsBrushPalette(for theme: AppTheme = App.context.theme) -> SettingsBrushPalette {
+    settingsBrushPalette(for: SettingsBrushMode(theme: theme))
+}
+
+func cardBackgroundBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBackground)
+}
+
+func cardHoverBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBackgroundPointerOver)
+}
+
+func cardPressedBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBackgroundPressed)
+}
+
+func cardBorderBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrush)
+}
+
+func dividerBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).divider)
+}
+
+func secondaryBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).secondary)
+}

--- a/Sources/RsUI/Controls/SettingsBrushes.swift
+++ b/Sources/RsUI/Controls/SettingsBrushes.swift
@@ -108,6 +108,19 @@ func cardPressedBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBr
     WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBackgroundPressed)
 }
 
+func cardForegroundBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardForeground)
+}
+
+func cardForegroundHoverBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardForegroundPointerOver)
+}
+
+func cardForegroundPressedBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardForegroundPressed)
+}
+
+
 func cardBorderBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
     WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrush)
 }

--- a/Sources/RsUI/Controls/SettingsBrushes.swift
+++ b/Sources/RsUI/Controls/SettingsBrushes.swift
@@ -1,5 +1,6 @@
 import UWP
 import WinUI
+import WindowsFoundation
 
 
 // MARK: - Brushes (internal)
@@ -33,7 +34,6 @@ private struct SettingsBrushPalette {
     let settingsCardForegroundDisabled: UWP.Color
 
     let settingsCardBorderBrush: UWP.Color
-    let settingsCardBorderBrushPointerOver: UWP.Color
     let settingsCardBorderBrushPressed: UWP.Color
     let settingsCardBorderBrushDisabled: UWP.Color
 
@@ -52,7 +52,6 @@ private struct SettingsBrushPalette {
         settingsCardForegroundDisabled: UWP.Color(a: 0x5C, r: 0x00, g: 0x00, b: 0x00),
 
         settingsCardBorderBrush: UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushPointerOver: UWP.Color(a: 0xE4, r: 0x00, g: 0x00, b: 0x00),
         settingsCardBorderBrushPressed: UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00),
         settingsCardBorderBrushDisabled: UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00),
 
@@ -72,7 +71,6 @@ private struct SettingsBrushPalette {
         settingsCardForegroundDisabled: UWP.Color(a: 0x5D, r: 0xFF, g: 0xFF, b: 0xFF),
 
         settingsCardBorderBrush: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushPointerOver: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
         settingsCardBorderBrushPressed: UWP.Color(a: 0x12, r: 0xFF, g: 0xFF, b: 0xFF),
         settingsCardBorderBrushDisabled: UWP.Color(a: 0x12, r: 0xFF, g: 0xFF, b: 0xFF),
 
@@ -114,8 +112,45 @@ func cardBorderBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBru
     WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrush)
 }
 
-func cardBorderBrushPointerOver(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrushPointerOver)
+func cardBorderBrushPointerOver(theme: AppTheme = App.context.theme) -> WinUI.Brush {
+    makeControlElevationBorderBrush(mode: SettingsBrushMode(theme: theme))
+}
+
+/// 此 Brush 是渐变, 比较特殊, 需要特殊处理.
+private func makeControlElevationBorderBrush(mode: SettingsBrushMode) -> WinUI.Brush {
+    let brush = WinUI.LinearGradientBrush()
+    brush.mappingMode = .absolute
+    brush.startPoint = WindowsFoundation.Point(x: 0, y: 0)
+    brush.endPoint = WindowsFoundation.Point(x: 0, y: 3)
+
+    let stops = WinUI.GradientStopCollection()
+
+    let topStop = WinUI.GradientStop()
+    topStop.offset = 0.33
+
+    let bottomStop = WinUI.GradientStop()
+    bottomStop.offset = 1.0
+
+    switch mode {
+    case .light:
+        topStop.color = UWP.Color(a: 0x29, r: 0x00, g: 0x00, b: 0x00)
+        bottomStop.color = UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00)
+
+        let transform = WinUI.CompositeTransform()
+        transform.scaleY = -1
+        transform.centerY = 0.5
+        brush.relativeTransform = transform
+
+    case .dark, .automatic:
+        topStop.color = UWP.Color(a: 0x18, r: 0xFF, g: 0xFF, b: 0xFF)
+        bottomStop.color = UWP.Color(a: 0x12, r: 0xFF, g: 0xFF, b: 0xFF)
+    }
+
+    stops.append(topStop)
+    stops.append(bottomStop)
+    brush.gradientStops = stops
+
+    return brush
 }
 
 func cardBorderBrushPressed(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {

--- a/Sources/RsUI/Controls/SettingsBrushes.swift
+++ b/Sources/RsUI/Controls/SettingsBrushes.swift
@@ -118,6 +118,10 @@ func cardBorderBrushPointerOver(theme: AppTheme = App.context.theme) -> WinUI.So
     WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrushPointerOver)
 }
 
+func cardBorderBrushPressed(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrushPressed)
+}
+
 func dividerBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
     WinUI.SolidColorBrush(settingsBrushPalette(for: theme).divider)
 }

--- a/Sources/RsUI/Controls/SettingsBrushes.swift
+++ b/Sources/RsUI/Controls/SettingsBrushes.swift
@@ -46,15 +46,15 @@ private struct SettingsBrushPalette {
         settingsCardBackgroundPressed: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
         settingsCardBackgroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
 
-        settingsCardForeground: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
-        settingsCardForegroundPointerOver: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
-        settingsCardForegroundPressed: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
-        settingsCardForegroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForeground: UWP.Color(a: 0xE4, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardForegroundPointerOver: UWP.Color(a: 0xE4, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardForegroundPressed: UWP.Color(a: 0x9E, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardForegroundDisabled: UWP.Color(a: 0x5C, r: 0x00, g: 0x00, b: 0x00),
 
-        settingsCardBorderBrush: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushPointerOver: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushPressed: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushDisabled: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrush: UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushPointerOver: UWP.Color(a: 0xE4, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushPressed: UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushDisabled: UWP.Color(a: 0x0F, r: 0x00, g: 0x00, b: 0x00),
 
         divider: UWP.Color(a: 15, r: 0, g: 0, b: 0),
         secondary: UWP.Color(a: 255, r: 96, g: 104, b: 112)
@@ -64,17 +64,17 @@ private struct SettingsBrushPalette {
         settingsCardBackground: UWP.Color(a: 0x0D, r: 0xFF, g: 0xFF, b: 0xFF),
         settingsCardBackgroundPointerOver: UWP.Color(a: 0x15, r: 0xFF, g: 0xFF, b: 0xFF),
         settingsCardBackgroundPressed: UWP.Color(a: 0x08, r: 0xFF, g: 0xFF, b: 0xFF),
-        settingsCardBackgroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardBackgroundDisabled: UWP.Color(a: 0x0B, r: 0xFF, g: 0xFF, b: 0xFF),
 
-        settingsCardForeground: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
-        settingsCardForegroundPointerOver: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
-        settingsCardForegroundPressed: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
-        settingsCardForegroundDisabled: UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9),
+        settingsCardForeground: UWP.Color(a: 0xFF, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardForegroundPointerOver: UWP.Color(a: 0xFF, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardForegroundPressed: UWP.Color(a: 0xC5, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardForegroundDisabled: UWP.Color(a: 0x5D, r: 0xFF, g: 0xFF, b: 0xFF),
 
-        settingsCardBorderBrush: UWP.Color(a: 25, r: 255, g: 255, b: 255),
+        settingsCardBorderBrush: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
         settingsCardBorderBrushPointerOver: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushPressed: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
-        settingsCardBorderBrushDisabled: UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00),
+        settingsCardBorderBrushPressed: UWP.Color(a: 0x12, r: 0xFF, g: 0xFF, b: 0xFF),
+        settingsCardBorderBrushDisabled: UWP.Color(a: 0x12, r: 0xFF, g: 0xFF, b: 0xFF),
 
         divider: UWP.Color(a: 24, r: 255, g: 255, b: 255),
         secondary: UWP.Color(a: 255, r: 174, g: 178, b: 190)
@@ -112,6 +112,10 @@ func cardPressedBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBr
 
 func cardBorderBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
     WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrush)
+}
+
+func cardBorderBrushPointerOver(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {
+    WinUI.SolidColorBrush(settingsBrushPalette(for: theme).settingsCardBorderBrushPointerOver)
 }
 
 func dividerBrush(theme: AppTheme = App.context.theme) -> WinUI.SolidColorBrush {

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -55,8 +55,6 @@ public class SettingsCard: ButtonBase {
     private override init() {
         super.init()
 
-        let isDark: Bool = App.context.theme.isDark
-
         self.horizontalAlignment = .stretch
         self.verticalAlignment = .stretch
         self.horizontalContentAlignment = .stretch
@@ -70,8 +68,8 @@ public class SettingsCard: ButtonBase {
         cardBorder.backgroundSizing = .innerBorderEdge
         cardBorder.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
         cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 4, topRight: 4, bottomRight: 4, bottomLeft: 4)
-        cardBorder.background = cardBackgroundBrush(isDark: isDark)
-        cardBorder.borderBrush = cardBorderBrush(isDark: isDark)
+        cardBorder.background = cardBackgroundBrush()
+        cardBorder.borderBrush = cardBorderBrush()
 
         self.content = cardBorder
     }
@@ -236,18 +234,15 @@ public class SettingsCard: ButtonBase {
 
     // Visual state transitions
     private func goToNormalState() {
-        let isDark = App.context.theme.isDark
-        cardBorder.background = cardBackgroundBrush(isDark: isDark)
+        cardBorder.background = cardBackgroundBrush()
     }
 
     private func goToPointerOverState() {
-        let isDark = App.context.theme.isDark
-        cardBorder.background = cardHoverBrush(isDark: isDark)
+        cardBorder.background = cardHoverBrush()
     }
 
     private func goToPressedState() {
-        let isDark = App.context.theme.isDark
-        cardBorder.background = cardPressedBrush(isDark: isDark)
+        cardBorder.background = cardPressedBrush()
     }
 
     // MARK: - Layout builder
@@ -259,8 +254,7 @@ public class SettingsCard: ButtonBase {
         content: FrameworkElement? = nil,
         actionIcon: FontIcon? = nil
     ) -> WinUI.Grid {
-        let isDark = App.context.theme.isDark
-        let secondaryForeground = secondaryBrush(isDark: isDark)
+        let secondaryForeground = secondaryBrush()
 
         let container = WinUI.Grid()
 
@@ -430,54 +424,4 @@ public class SettingsCard: ButtonBase {
         }()
         return tb
     }
-}
-
-// MARK: - Brushes (internal)
-
-func cardBackgroundBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 0x0D, r: 0xFF, g: 0xFF, b: 0xFF)
-            : UWP.Color(a: 0xB3, r: 0xFF, g: 0xFF, b: 0xFF)
-    )
-}
-
-private func cardHoverBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 0x15, r: 0xFF, g: 0xFF, b: 0xFF)
-            : UWP.Color(a: 0x80, r: 0xF9, g: 0xF9, b: 0xF9)
-    )
-}
-
-private func cardPressedBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 0x08, r: 0xFF, g: 0xFF, b: 0xFF)
-            : UWP.Color(a: 0x4D, r: 0xF9, g: 0xF9, b: 0xF9)
-    )
-}
-
-func cardBorderBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 25, r: 255, g: 255, b: 255)
-            : UWP.Color(a: 0x19, r: 0x00, g: 0x00, b: 0x00)
-    )
-}
-
-func dividerBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 24, r: 255, g: 255, b: 255)
-            : UWP.Color(a: 15, r: 0, g: 0, b: 0)
-    )
-}
-
-func secondaryBrush(isDark: Bool) -> WinUI.SolidColorBrush {
-    WinUI.SolidColorBrush(
-        isDark
-            ? UWP.Color(a: 255, r: 174, g: 178, b: 190)
-            : UWP.Color(a: 255, r: 96, g: 104, b: 112)
-    )
 }

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -70,6 +70,7 @@ public class SettingsCard: ButtonBase {
         cardBorder.cornerRadius = WinUI.CornerRadius(topLeft: 4, topRight: 4, bottomRight: 4, bottomLeft: 4)
         cardBorder.background = cardBackgroundBrush()
         cardBorder.borderBrush = cardBorderBrush()
+        self.foreground = cardForegroundBrush()
 
         self.content = cardBorder
     }
@@ -236,16 +237,19 @@ public class SettingsCard: ButtonBase {
     private func goToNormalState() {
         cardBorder.background = cardBackgroundBrush()
         cardBorder.borderBrush = cardBorderBrush()
+        self.foreground = cardForegroundBrush()
     }
 
     private func goToPointerOverState() {
         cardBorder.background = cardHoverBrush()
         cardBorder.borderBrush = cardBorderBrushPointerOver()
+        self.foreground = cardForegroundHoverBrush()
     }
 
     private func goToPressedState() {
         cardBorder.background = cardPressedBrush()
         cardBorder.borderBrush = cardBorderBrushPressed()
+        self.foreground = cardForegroundPressedBrush()
     }
 
     // MARK: - Layout builder

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -41,6 +41,7 @@ public class SettingsCard: ButtonBase {
     let cardBorder = WinUI.Border()
     private var rootGrid: WinUI.Grid?
     private var actionIconHolder: Viewbox?
+    private weak var interactionVisualTarget: WinUI.Border?
 
     // Event cleanups for proper handler removal
     private var pointerEnteredToken: EventCleanup?
@@ -183,6 +184,12 @@ public class SettingsCard: ButtonBase {
         cardBorder.padding = WinUI.Thickness(left: 58, top: 8, right: rightPadding, bottom: 8)
     }
 
+    /// Redirects hover/pressed visuals to an outer border, used by SettingsExpander headers.
+    func setInteractionVisualTarget(_ target: WinUI.Border?) {
+        interactionVisualTarget = target
+        goToNormalState()
+    }
+
     // MARK: - State management
 
     private func onIsClickEnabledChanged() {
@@ -235,20 +242,23 @@ public class SettingsCard: ButtonBase {
 
     // Visual state transitions
     private func goToNormalState() {
-        cardBorder.background = cardBackgroundBrush()
-        cardBorder.borderBrush = cardBorderBrush()
+        let visualTarget = interactionVisualTarget ?? cardBorder
+        visualTarget.background = cardBackgroundBrush()
+        visualTarget.borderBrush = cardBorderBrush()
         self.foreground = cardForegroundBrush()
     }
 
     private func goToPointerOverState() {
-        cardBorder.background = cardHoverBrush()
-        cardBorder.borderBrush = cardBorderBrushPointerOver()
+        let visualTarget = interactionVisualTarget ?? cardBorder
+        visualTarget.background = cardHoverBrush()
+        visualTarget.borderBrush = cardBorderBrushPointerOver()
         self.foreground = cardForegroundHoverBrush()
     }
 
     private func goToPressedState() {
-        cardBorder.background = cardPressedBrush()
-        cardBorder.borderBrush = cardBorderBrushPressed()
+        let visualTarget = interactionVisualTarget ?? cardBorder
+        visualTarget.background = cardPressedBrush()
+        visualTarget.borderBrush = cardBorderBrushPressed()
         self.foreground = cardForegroundPressedBrush()
     }
 

--- a/Sources/RsUI/Controls/SettingsCard.swift
+++ b/Sources/RsUI/Controls/SettingsCard.swift
@@ -235,14 +235,17 @@ public class SettingsCard: ButtonBase {
     // Visual state transitions
     private func goToNormalState() {
         cardBorder.background = cardBackgroundBrush()
+        cardBorder.borderBrush = cardBorderBrush()
     }
 
     private func goToPointerOverState() {
         cardBorder.background = cardHoverBrush()
+        cardBorder.borderBrush = cardBorderBrushPointerOver()
     }
 
     private func goToPressedState() {
         cardBorder.background = cardPressedBrush()
+        cardBorder.borderBrush = cardBorderBrushPressed()
     }
 
     // MARK: - Layout builder

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -112,7 +112,7 @@ public class SettingsExpander: StackPanel {
     // MARK: - Setup
 
     private func setup(headerCard: SettingsCard) {
-        let isDark = App.context.theme.isDark
+        let theme = App.context.theme
 
         headerCard.isClickEnabled = true
         headerCard.suppressCardStyling()
@@ -123,7 +123,7 @@ public class SettingsExpander: StackPanel {
         }
 
         expandedHost.renderTransform = expandedTransform
-        buildExpandedContent(isDark: isDark)
+        buildExpandedContent(theme: theme)
 
         let cardStack = WinUI.StackPanel()
         cardStack.orientation = .vertical
@@ -133,15 +133,15 @@ public class SettingsExpander: StackPanel {
 
         let outerCard = WinUI.Border()
         outerCard.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
-        outerCard.background = cardBackgroundBrush(isDark: isDark)
-        outerCard.borderBrush = cardBorderBrush(isDark: isDark)
+        outerCard.background = cardBackgroundBrush(theme: theme)
+        outerCard.borderBrush = cardBorderBrush(theme: theme)
         outerCard.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
         outerCard.child = cardStack
 
         self.children.append(outerCard)
     }
 
-    private func buildExpandedContent(isDark: Bool) {
+    private func buildExpandedContent(theme: AppTheme) {
         // Clear existing children (keep transform)
         while expandedHost.children.count > 0 {
             expandedHost.children.removeAt(0)
@@ -159,7 +159,7 @@ public class SettingsExpander: StackPanel {
             item.applyExpanderItemPadding()
             // Top border only (0,1,0,0) to match WCTK item separator style
             item.cardBorder.borderThickness = WinUI.Thickness(left: 0, top: 1, right: 0, bottom: 0)
-            item.cardBorder.borderBrush = dividerBrush(isDark: isDark)
+            item.cardBorder.borderBrush = dividerBrush(theme: theme)
             expandedHost.children.append(item)
         }
 
@@ -170,8 +170,7 @@ public class SettingsExpander: StackPanel {
     }
 
     private func rebuildItems() {
-        let isDark = App.context.theme.isDark
-        buildExpandedContent(isDark: isDark)
+        buildExpandedContent(theme: App.context.theme)
     }
 
     // MARK: - Animation

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -132,7 +132,7 @@ public class SettingsExpander: StackPanel {
         cardStack.children.append(expandedHost)
 
         let outerCard = WinUI.Border()
-        outerCard.cornerRadius = WinUI.CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
+        outerCard.cornerRadius = WinUI.CornerRadius(topLeft: 4, topRight: 4, bottomRight: 4, bottomLeft: 4)
         outerCard.background = cardBackgroundBrush(theme: theme)
         outerCard.borderBrush = cardBorderBrush(theme: theme)
         outerCard.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)

--- a/Sources/RsUI/Controls/SettingsExpander.swift
+++ b/Sources/RsUI/Controls/SettingsExpander.swift
@@ -42,6 +42,7 @@ public class SettingsExpander: StackPanel {
         return t
     }()
 
+    private var interactionVisualTarget: WinUI.Border?
     private var items: [SettingsCard] = []
 
     // MARK: - Init
@@ -137,6 +138,8 @@ public class SettingsExpander: StackPanel {
         outerCard.borderBrush = cardBorderBrush(theme: theme)
         outerCard.borderThickness = WinUI.Thickness(left: 1, top: 1, right: 1, bottom: 1)
         outerCard.child = cardStack
+        interactionVisualTarget = outerCard
+        headerCard.setInteractionVisualTarget(outerCard)
 
         self.children.append(outerCard)
     }


### PR DESCRIPTION
1. clickable card 鼠标悬停样式不同

WCTK实现【鼠标悬停样式不同，WCTK有三维的阴影】的方式的其边框是一个渐变的笔刷，此次更新补充了此笔刷处理。

<img width="2347" height="321" alt="image" src="https://github.com/user-attachments/assets/2f566d62-2f87-4adc-a067-29950f9a7e72" />

2. expander 圆角不一致

圆角由8改变为4。

3. dark mode 下边框和间距看起来不一致

之前 About expander 自己定义了 background、border、divider、padding 等 dark mode 样式，和 SettingsCard 的共享 brush 不一致。现在 About 区域的外层卡片、边框、hover 状态都由 RsUI 控件统一管理，dark mode 下的视觉表现会和其他设置卡片保持一致。


