### PR TITLE
Feature/top level tabview

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
@@ -1,0 +1,139 @@
+import Foundation
+import WindowsFoundation
+import UWP
+import WinUI
+
+extension MainWindow {
+    func setupContent() {
+        let root = Grid()
+
+        // 设置行定义
+        let titleRowDef = RowDefinition()
+        titleRowDef.height = GridLength(value: 1, gridUnitType: .auto)
+        root.rowDefinitions.append(titleRowDef)
+        
+        let contentRowDef = RowDefinition()
+        contentRowDef.height = GridLength(value: 1, gridUnitType: .star)
+        root.rowDefinitions.append(contentRowDef)
+        
+        root.children.append(titleBar)
+        try? Grid.setRow(titleBar, 0)
+        try? setTitleBar(titleBar)
+
+        configureNavigationViewSelection()
+        configureTabViewEvents()
+        setupTabDragHint()
+        configurePaneEvents()
+
+        let navWrapper = makeNavigationWrapper()
+        root.children.append(navWrapper)
+        try? Grid.setRow(navWrapper, 1)
+
+        self.content = root
+    }
+
+    private func configureNavigationViewSelection() {
+        navigationView.selectionChanged.addHandler { [weak self] _, args in
+            guard let self, let args, !self.isSyncingSelection else { return }
+
+            if args.isSettingsSelected {
+                navigate(to: SettingsPage(), transitionInfoOverride: SuppressNavigationTransitionInfo())
+            } else if
+                let item = args.selectedItem as? NavigationViewItem,
+                let tag = item.tag,
+                let str = tag as? HString,
+                let url = URL(string: String(hString: str)) {
+                _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
+            }
+        }
+    }
+
+    private func configureTabViewEvents() {
+        tabView.selectionChanged.addHandler { [weak self] sender, args in
+            guard let self, !self.isSyncingTabSelection else { return }
+            guard let item = self.selectedTabViewItem(sender: sender, args: args) else { return }
+            guard let tab = self.tab(for: item) else { return }
+            self.switchToTab(tab)
+        }
+
+        tabView.tabCloseRequested.addHandler { [weak self] _, args in
+            guard let self, let args, let item = args.tab else { return }
+            self.closeTab(for: item)
+        }
+
+        tabView.addTabButtonClick.addHandler { [weak self] _, _ in
+            self?.openNewTabFromTabStrip()
+        }
+
+        // Source: record which tab is being dragged and expose it via static state for cross-window drop
+        tabView.tabDragStarting.addHandler { [weak self] _, args in
+            guard let self, let args, let item = args.tab else { return }
+            guard let tab = self.tab(for: item) else { return }
+            guard let url = tab.currentPage?.url else { return }
+            self.draggingTabForDrop = tab
+            MainWindow.activeDrag = DragState(sourceWindowID: ObjectIdentifier(self), tabURL: url)
+        }
+
+        // Source: flag that the tab was physically dropped outside (vs drag cancelled by Escape)
+        tabView.tabDroppedOutside.addHandler { [weak self] _, _ in
+            self?.dragDroppedOutside = true
+        }
+
+        // Source: decide outcome once drag completes
+        tabView.tabDragCompleted.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            let wasDroppedOutside = self.dragDroppedOutside
+            defer {
+                self.dragDroppedOutside = false
+                self.draggingTabForDrop = nil
+                MainWindow.activeDrag = nil
+            }
+            guard let tab = self.draggingTabForDrop else { return }
+            guard self.viewModel.tabs.count > 1 else { return }
+            guard self.viewModel.tabs.contains(where: { $0 === tab }) else { return }
+
+            if args.dropResult == .none {
+                // No valid drop target accepted the drag; tear-off only when physically dropped (not Escape)
+                guard wasDroppedOutside else { return }
+                let url = tab.currentPage?.url
+                self.viewModel.close(tab: tab)
+                self.renderSelectedTab()
+                if let url { MainWindow.openDetachedWindow(navigatingTo: url) }
+            } else {
+                // Another window's TabView accepted the drop; close the tab from this window
+                self.viewModel.close(tab: tab)
+                self.renderSelectedTab()
+            }
+        }
+
+        // Destination: accept tab drops from other windows' TabViews
+        tabView.dragOver.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
+            args.acceptedOperation = .move
+        }
+        tabView.drop.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
+            _ = self.navigate(to: drag.tabURL, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
+        }
+    }
+
+    private func configurePaneEvents() {
+        navigationView.paneClosed.addHandler { [weak self] _, _ in
+            self?.splitterBorder.visibility = .collapsed
+        }
+        navigationView.paneOpened.addHandler { [weak self] _, _ in
+            self?.splitterBorder.visibility = .visible
+        }
+    }
+
+    private func makeNavigationWrapper() -> Grid {
+        let navWrapper = Grid()
+        navWrapper.children.append(navigationView)
+        splitterBorder = makeSplitterBorder()
+        navWrapper.children.append(splitterBorder)
+        try? Canvas.setZIndex(splitterBorder, 10)
+        return navWrapper
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+Navigation.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Navigation.swift
@@ -1,0 +1,180 @@
+import Foundation
+import WindowsFoundation
+import UWP
+import WinUI
+
+extension MainWindow {
+    func navigate(
+        to page: Page,
+        mode: NavigationOpenMode = .inplace,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) {
+        let effective = resolveOpenMode(mode)
+        performNavigate(to: page, mode: effective, transitionInfoOverride: transitionInfoOverride)
+    }
+
+    @discardableResult
+    func navigate(
+        to url: URL,
+        mode: NavigationOpenMode = .inplace,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Bool {
+        let effective = resolveOpenMode(mode)
+        return performNavigate(to: url, mode: effective, transitionInfoOverride: transitionInfoOverride)
+    }
+
+    /// NavigationViewItem 上 Ctrl+click 设置的 `openInNewTabRequested` 标记会把
+    /// `.inplace` 升级为 `.newTab`；调用者显式指定的非 inplace 模式不被覆盖。
+    private func resolveOpenMode(_ requested: NavigationOpenMode) -> NavigationOpenMode {
+        let flag = openInNewTabRequested
+        openInNewTabRequested = false
+        if requested == .inplace && flag {
+            return .newTab
+        }
+        return requested
+    }
+
+    private func performNavigate(
+        to page: Page,
+        mode: NavigationOpenMode,
+        transitionInfoOverride: NavigationTransitionInfo?
+    ) {
+        if mode == .newWindow {
+            MainWindow.openDetachedWindow(navigatingTo: page.url)
+            return
+        }
+        viewModel.navigate(
+            to: page,
+            transitionInfoOverride: transitionInfoOverride,
+            inNewTab: mode != .inplace,
+            switchToTab: mode != .newTabBackground
+        )
+        renderSelectedTab()
+    }
+
+    @discardableResult
+    private func performNavigate(
+        to url: URL,
+        mode: NavigationOpenMode,
+        transitionInfoOverride: NavigationTransitionInfo?
+    ) -> Bool {
+        if mode == .newWindow {
+            MainWindow.openDetachedWindow(navigatingTo: url)
+            return true
+        }
+        // 仅在 inplace 模式下短路；其他模式（newTab / newTabBackground）允许重复打开同 URL
+        if mode == .inplace, viewModel.currentPage?.url == url {
+            return true
+        }
+
+        if url == SettingsPage.url {
+            performNavigate(to: SettingsPage(), mode: mode, transitionInfoOverride: transitionInfoOverride)
+            return true
+        } else {
+            let context = WindowContext(owner: self)
+            for module in App.context.modules {
+                if let page = module.navigationRequested(for: url, in: context) {
+                    performNavigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
+                    return true
+                }
+            }
+        }
+        return false
+    }
+ 
+
+    func firstNavigationItemURL() -> URL? {
+        return firstNavigationItemURL(in: navigationView.menuItems)
+            ?? firstNavigationItemURL(in: navigationView.footerMenuItems)
+    }
+
+    private func firstNavigationItemURL(in items: AnyIVector<Any?>?) -> URL? {
+        guard let items else { return nil }
+
+        for item in items {
+            guard let navItem = item as? NavigationViewItem else { continue }
+            if
+                let tag = navItem.tag,
+                let str = tag as? HString,
+                let url = URL(string: String(hString: str)) {
+                return url
+            }
+            if let url = firstNavigationItemURL(in: navItem.menuItems) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    func syncNavigationSelection(for url: URL) {
+        isSyncingSelection = true
+        defer { isSyncingSelection = false }
+        
+        navigationView.selectItem(with: url)
+    }
+
+    private func captureOpenInNewTabRequested(_ args: PointerRoutedEventArgs?) {
+        guard let args = args else { return }
+        let rawValue = Int(args.keyModifiers.rawValue)
+        openInNewTabRequested = (rawValue & 0x1) != 0
+    }
+
+    func appendNavigationItem(_ item: NavigationViewItemBase, _ isFooter: Bool) {
+        item.pointerPressed.addHandler { [weak self, weak item] _, args in
+            guard let self else { return }
+            self.captureOpenInNewTabRequested(args)
+            guard self.openInNewTabRequested, let item else { return }
+            self.openSelectedNavigationItemInNewTabIfNeeded(item, args)
+        }
+        if isFooter {
+            navigationView.footerMenuItems.append(item)
+        } else {
+            navigationView.menuItems.append(item)
+        }
+    }
+
+    private func openSelectedNavigationItemInNewTabIfNeeded(_ item: NavigationViewItemBase, _ args: PointerRoutedEventArgs?) {
+        guard isNavigationItemSelected(item), let url = url(for: item) else { return }
+
+        args?.handled = true
+        openInNewTabRequested = false
+
+        let queued = (try? dispatcherQueue?.tryEnqueue { [weak self] in
+            guard let self else { return }
+            _ = self.navigate(
+                to: url,
+                mode: .newTab,
+                transitionInfoOverride: SuppressNavigationTransitionInfo()
+            )
+        }) ?? false
+
+        if !queued {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                _ = self.navigate(
+                    to: url,
+                    mode: .newTab,
+                    transitionInfoOverride: SuppressNavigationTransitionInfo()
+                )
+            }
+        }
+    }
+
+    private func isNavigationItemSelected(_ item: NavigationViewItemBase) -> Bool {
+        guard let selectedItem = navigationView.selectedItem as? NavigationViewItemBase else { return false }
+        return selectedItem === item
+    }
+
+    private func url(for item: NavigationViewItemBase) -> URL? {
+        guard
+            let navItem = item as? NavigationViewItem,
+            let tag = navItem.tag,
+            let str = tag as? HString
+        else {
+            return nil
+        }
+
+        return URL(string: String(hString: str))
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
@@ -1,0 +1,103 @@
+import Foundation
+import UWP
+import WinUI
+
+final class PageViewParts {
+    var contentBorder: Border?
+    var headerBorder: Border?
+}
+
+extension MainWindow {
+    func title(for page: Page?) -> String {
+        guard let page else { return MainWindow.tr("New Tab") }
+        if let text = page.header as? String, !text.isEmpty {
+            return text
+        }
+
+        let host = page.url.host ?? page.url.absoluteString
+        return host.isEmpty ? page.url.absoluteString : host
+    }
+
+    func makePageView(_ page: Page, for tab: MainWindowTab) -> UIElement {
+        let tabID = ObjectIdentifier(tab)
+        let parts = tabPageViewPartsByID[tabID] ?? PageViewParts()
+        parts.contentBorder?.child = nil
+        parts.headerBorder?.child = nil
+        parts.contentBorder = nil
+        parts.headerBorder = nil
+        tabPageViewPartsByID[tabID] = parts
+
+        // String header → 同时渲染为页面顶部 28pt 大标题 + 通过 title(for:) 用作 Tab 标签
+        // UIElement header → 直接渲染到页面顶部
+        let headerView: UIElement
+        if let text = page.header as? String {
+            let tb = TextBlock()
+            tb.text = text
+            tb.fontSize = 28
+            tb.fontWeight = FontWeights.semiBold
+            tb.textWrapping = .wrap
+            headerView = tb
+        } else if let view = page.header as? UIElement {
+            headerView = view
+        } else {
+            return page.content
+        }
+
+        let grid = Grid()
+        let autoRow = RowDefinition()
+        autoRow.height = GridLength(value: 0, gridUnitType: .auto)
+        let starRow = RowDefinition()
+        starRow.height = GridLength(value: 1, gridUnitType: .star)
+        grid.rowDefinitions.append(autoRow)
+        grid.rowDefinitions.append(starRow)
+
+        // Row 0: header — margin matches WinUI default NavigationViewHeaderMargin (56,44,0,0)
+        let headerBorder = Border()
+        headerBorder.margin = Thickness(left: 56, top: 44, right: 0, bottom: 0)
+        MainWindow.safelyAssignChild(headerView, toBorder: headerBorder)
+        parts.headerBorder = headerBorder
+
+        // Row 1: content
+        let contentBorder = Border()
+        let pageContent = page.content
+        MainWindow.safelyAssignChild(pageContent, toBorder: contentBorder)
+        parts.contentBorder = contentBorder
+
+        try? Grid.setRow(headerBorder, 0)
+        try? Grid.setRow(contentBorder, 1)
+        grid.children.append(headerBorder)
+        grid.children.append(contentBorder)
+        return grid
+    }
+
+    /// 把 `child` 赋值给 `border.child` 之前先显式从原 parent 断开，
+    /// 防御 Page 把 UIElement 作为存储属性返回导致的 
+    /// "Element is already the child of another element" WinRT 异常 ——
+    /// 这种异常发生在 COM callback 路径里，会从 `try!` 抛出但传不到 Swift 主线程，
+    /// 进程不会真正终止，但相关 UI 操作会失败、日志会污染。
+    private static func safelyAssignChild(_ child: UIElement, toBorder border: Border) {
+        detachFromVisualParent(child)
+        border.child = child
+    }
+
+    /// 把 element 从其当前 visual parent 上断开。覆盖 Border / Panel / ContentControl /
+    /// ContentPresenter 这几种最常见的 parent 类型。其他类型（如 ItemsControl 直接挂载
+    /// arbitrary UIElement，理论上不应该出现）打日志方便排查。
+    private static func detachFromVisualParent(_ element: UIElement) {
+        guard let parent = try? VisualTreeHelper.getParent(element) else { return }
+        if let parentBorder = parent as? Border {
+            parentBorder.child = nil
+        } else if let parentPanel = parent as? Panel {
+            var idx: UInt32 = 0
+            if parentPanel.children.indexOf(element, &idx) {
+                parentPanel.children.removeAt(idx)
+            }
+        } else if let parentContent = parent as? ContentControl {
+            parentContent.content = nil
+        } else if let parentPresenter = parent as? ContentPresenter {
+            parentPresenter.content = nil
+        } else {
+            print("[RsUI] detachFromVisualParent: unsupported parent type \(type(of: parent)) for child \(type(of: element)) — 'Element is already the child of another element' may follow")
+        }
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+Splitter.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Splitter.swift
@@ -1,0 +1,65 @@
+import UWP
+import WinAppSDK
+import WinUI
+
+extension MainWindow {
+    func makeSplitterBorder() -> Border {
+        let b = Border()
+        b.width = splitterWidth
+        b.verticalAlignment = .stretch
+        b.horizontalAlignment = .left
+        b.background = SolidColorBrush(UWP.Color(a: 0, r: 0, g: 0, b: 0)) // transparent hit area
+        b.margin = Thickness(
+            left: navigationView.openPaneLength - splitterWidth / 2,
+            top: 0, right: 0, bottom: 0
+        )
+        b.visibility = viewModel.windowLayout.navigationViewPaneOpen ? .visible : .collapsed
+        b.protectedCursor = try? InputSystemCursor.create(.sizeWestEast)
+
+        setupSplitterPointerEvents(b)
+        return b
+    }
+
+    private func setupSplitterPointerEvents(_ splitter: Border) {
+        splitter.pointerPressed.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            let point = try? args.getCurrentPoint(nil) // window-relative
+            self.isDraggingSplitter = true
+            self.dragStartX = Double(point?.position.x ?? 0)
+            self.dragStartPaneLength = self.navigationView.openPaneLength
+            _ = try? self.splitterBorder.capturePointer(args.pointer)
+            args.handled = true
+        }
+
+        splitter.pointerMoved.addHandler { [weak self] _, args in
+            guard let self, self.isDraggingSplitter, let args else { return }
+            let point = try? args.getCurrentPoint(nil) // window-relative
+            let currentX = Double(point?.position.x ?? 0)
+            let delta = currentX - self.dragStartX
+            let newLength = min(self.viewModel.windowLayout.navigationViewMaxPaneLength, max(self.viewModel.windowLayout.navigationViewMinPaneLength, self.dragStartPaneLength + delta))
+            self.applyPaneLength(newLength)
+            args.handled = true
+        }
+
+        splitter.pointerReleased.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            self.isDraggingSplitter = false
+            try? self.splitterBorder.releasePointerCapture(args.pointer)
+            args.handled = true
+        }
+
+        splitter.pointerCaptureLost.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            self.isDraggingSplitter = false
+        }
+    }
+
+    private func applyPaneLength(_ length: Double) {
+        navigationView.openPaneLength = length
+        navigationView.expandedModeThresholdWidth = length + viewModel.windowLayout.navigationViewExpandedModeThresholdContentWidth
+        splitterBorder.margin = Thickness(
+            left: length - splitterWidth / 2,
+            top: 0, right: 0, bottom: 0
+        )
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+TabFrames.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+TabFrames.swift
@@ -1,0 +1,56 @@
+import Foundation
+import WinUI
+
+extension MainWindow {
+    func frame(for tab: MainWindowTab) -> PageTransitionHost {
+        let id = ObjectIdentifier(tab)
+        if let frame = tabFramesByID[id] {
+            return frame
+        }
+
+        let frame = PageTransitionHost()
+        frame.visibility = .collapsed
+        tabFramesByID[id] = frame
+        tabContentHost.children.append(frame)
+        return frame
+    }
+
+    func showFrame(for tab: MainWindowTab) -> PageTransitionHost {
+        let id = ObjectIdentifier(tab)
+        let selectedFrame = frame(for: tab)
+        guard visibleTabFrameID != id else {
+            return selectedFrame
+        }
+
+        for (frameID, frame) in tabFramesByID {
+            frame.visibility = frameID == id ? .visible : .collapsed
+        }
+        visibleTabFrameID = id
+        return selectedFrame
+    }
+
+    func hideAllTabFrames() {
+        for frame in tabFramesByID.values {
+            frame.visibility = .collapsed
+        }
+        visibleTabFrameID = nil
+    }
+
+    func removeClosedTabFrames(activeIDs: Set<ObjectIdentifier>) {
+        let closedIDs = tabFramesByID.keys.filter { !activeIDs.contains($0) }
+        for id in closedIDs {
+            guard let frame = tabFramesByID.removeValue(forKey: id) else { continue }
+            removeTabFrame(frame)
+            if visibleTabFrameID == id {
+                visibleTabFrameID = nil
+            }
+        }
+    }
+
+    private func removeTabFrame(_ frame: PageTransitionHost) {
+        var idx: UInt32 = 0
+        if tabContentHost.children.indexOf(frame, &idx) {
+            tabContentHost.children.removeAt(idx)
+        }
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
@@ -1,0 +1,94 @@
+import Foundation
+import WindowsFoundation
+import UWP
+import WinUI
+
+extension MainWindow {
+    func tab(for item: TabViewItem) -> MainWindowTab? {
+        // Primary: stable name-based lookup (avoids WinRT projection identity instability)
+        if let id = tabIDByName[item.name], let tab = viewModel.tabs.first(where: { ObjectIdentifier($0) == id }) {
+            return tab
+        }
+        // Fallback: identity comparison
+        for tab in viewModel.tabs {
+            if tabItemsByID[ObjectIdentifier(tab)] === item {
+                return tab
+            }
+        }
+        return nil
+    }
+
+    func selectedTabViewItem(sender: Any?, args: SelectionChangedEventArgs?) -> TabViewItem? {
+        if
+            let args,
+            let addedItems = args.addedItems,
+            addedItems.size > 0,
+            let item = addedItems.getAt(0) as? TabViewItem {
+            return item
+        }
+
+        if let tabView = sender as? TabView {
+            return tabView.selectedItem as? TabViewItem
+        }
+
+        return tabView.selectedItem as? TabViewItem
+    }
+
+    func switchToTab(_ tab: MainWindowTab) {
+        guard viewModel.selectedTab !== tab else { return }
+        viewModel.select(tab: tab)
+        renderSelectedTab()
+    }
+
+    func closeTab(for item: TabViewItem) {
+        guard let tab = tab(for: item) else { return }
+        viewModel.close(tab: tab)
+        renderSelectedTab()
+    }
+
+    func closeOtherTabs() {
+        viewModel.closeOtherTabs()
+        renderSelectedTab()
+    }
+
+    func setupTabDragHint() {
+        let hintText = TextBlock()
+        hintText.text = MainWindow.tr("拖到其他窗口可合并，拖到窗口外释放可分离为新窗口")
+        hintText.fontSize = 12
+        hintText.textWrapping = .wrap
+        hintText.maxWidth = 460
+        hintText.foreground = SolidColorBrush(UWP.Color(a: 255, r: 245, g: 249, b: 255))
+
+        let hintBorder = Border()
+        hintBorder.background = SolidColorBrush(UWP.Color(a: 230, r: 21, g: 94, b: 175))
+        hintBorder.borderBrush = SolidColorBrush(UWP.Color(a: 255, r: 166, g: 215, b: 255))
+        hintBorder.borderThickness = Thickness(left: 1, top: 1, right: 1, bottom: 1)
+        hintBorder.cornerRadius = CornerRadius(topLeft: 10, topRight: 10, bottomRight: 10, bottomLeft: 10)
+        hintBorder.padding = Thickness(left: 12, top: 8, right: 12, bottom: 8)
+        hintBorder.horizontalAlignment = .center
+        hintBorder.verticalAlignment = .top
+        hintBorder.margin = Thickness(left: 0, top: 12, right: 0, bottom: 0)
+        hintBorder.opacity = 0
+        hintBorder.visibility = .collapsed
+        hintBorder.isHitTestVisible = false
+        hintBorder.child = hintText
+        try? Canvas.setZIndex(hintBorder, 99)
+        tabContentHost.children.append(hintBorder)
+        tabDragHintBorder = hintBorder
+
+        tabView.tabDragStarting.addHandler { [weak hintBorder] _, _ in
+            hintBorder?.visibility = .visible
+            hintBorder?.opacity = 1
+        }
+        tabView.tabDragCompleted.addHandler { [weak hintBorder] _, _ in
+            hintBorder?.opacity = 0
+            hintBorder?.visibility = .collapsed
+        }
+    }
+
+    static func openDetachedWindow(navigatingTo url: URL) {
+        let window = MainWindow()
+        window.initialNavigationURL = url
+        try? window.activate()
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
@@ -1,0 +1,180 @@
+import Foundation
+import WindowsFoundation
+import UWP
+import WinUI
+
+extension MainWindow {
+    func renderSelectedTab() {
+        syncTabItems()
+        updateTabStripVisibility()
+
+        guard let tab = viewModel.selectedTab, let page = tab.currentPage else {
+            navigationView.header = nil
+            hideAllTabFrames()
+            navigationView.selectedItem = nil
+            backButton.isEnabled = false
+            forwardButton.isEnabled = false
+            return
+        }
+
+        navigationView.header = nil
+        updateTabItemState(for: tab)
+        let frame = showFrame(for: tab)
+
+        if tab.needsRender {
+            let effectiveTransitionInfo: NavigationTransitionInfo?
+            if isFirstNavigation {
+                effectiveTransitionInfo = SuppressNavigationTransitionInfo()
+                isFirstNavigation = false
+            } else {
+                effectiveTransitionInfo = tab.navigationTransitionInfo
+            }
+            frame.transition(
+                to: makePageView(page, for: tab),
+                transitionInfo: effectiveTransitionInfo
+            )
+            tab.needsRender = false
+        }
+
+        let tabItem = tabViewItem(for: tab)
+        if !tabViewItem(tabView.selectedItem as? TabViewItem, represents: ObjectIdentifier(tab)) {
+            isSyncingTabSelection = true
+            tabView.selectedItem = tabItem
+            isSyncingTabSelection = false
+        }
+
+        syncNavigationSelection(for: page.url)
+        backButton.isEnabled = !tab.backwardPages.isEmpty
+        forwardButton.isEnabled = !tab.forwardPages.isEmpty
+    }
+
+    private func syncTabItems() {
+        guard let items = tabView.tabItems else { return }
+
+        let ids = viewModel.tabs.map { ObjectIdentifier($0) }
+        let activeIDs = Set(ids)
+        tabItemsByID = tabItemsByID.filter { activeIDs.contains($0.key) }
+        tabIDByName = tabIDByName.filter { activeIDs.contains($0.value) }
+        tabTitlesByID = tabTitlesByID.filter { activeIDs.contains($0.key) }
+        tabClosableByID = tabClosableByID.filter { activeIDs.contains($0.key) }
+        tabPageViewPartsByID = tabPageViewPartsByID.filter { activeIDs.contains($0.key) }
+        removeClosedTabFrames(activeIDs: activeIDs)
+
+        guard ids != tabStripIDs else {
+            return
+        }
+
+        isSyncingTabSelection = true
+        defer { isSyncingTabSelection = false }
+
+        // Step 1: 按身份精确移除 items 中所有不再属于 viewModel.tabs 的 TabViewItem。
+        //   旧版只 `items.removeAt(items.size - 1)` 截尾，关闭非末尾 tab 时残留错位 item，
+        //   后续 insertAt 会试图把同一 UIElement 插到已存在位置 → "two parents" WinRT 异常。
+        var i: UInt32 = 0
+        while i < items.size {
+            if let item = items.getAt(i) as? TabViewItem,
+               let id = tabIDByName[item.name],
+               activeIDs.contains(id) {
+                i += 1
+            } else {
+                items.removeAt(i)
+            }
+        }
+
+        // Step 2: 重排到目标顺序。如果目标 tabItem 已在 items 中（错位），先从原位置移除再插入。
+        for (index, tab) in viewModel.tabs.enumerated() {
+            let id = ObjectIdentifier(tab)
+            let tabItem = tabViewItem(for: tab)
+            if UInt32(index) < items.size,
+               let item = items.getAt(UInt32(index)) as? TabViewItem,
+               tabViewItem(item, represents: id) {
+                continue
+            }
+
+            // 找一下 tabItem 是否已在 items 别处
+            var existingIndex: UInt32? = nil
+            var j: UInt32 = 0
+            while j < items.size {
+                if let item = items.getAt(j) as? TabViewItem,
+                   tabViewItem(item, represents: id) {
+                    existingIndex = j
+                    break
+                }
+                j += 1
+            }
+            if let existingIndex {
+                items.removeAt(existingIndex)
+            }
+            items.insertAt(UInt32(index), tabItem)
+        }
+        tabStripIDs = ids
+        updateAllTabItemCloseStates()
+    }
+
+    private func tabViewItem(_ item: TabViewItem?, represents id: ObjectIdentifier) -> Bool {
+        guard let item else { return false }
+        if tabIDByName[item.name] == id {
+            return true
+        }
+        return tabItemsByID[id] === item
+    }
+
+    private func updateTabStripVisibility() {
+        tabView.visibility = viewModel.tabs.count <= 1 ? .collapsed : .visible
+    }
+
+    func openNewTabFromTabStrip() {
+        if let url = firstNavigationItemURL() {
+            _ = navigate(to: url, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
+        } else {
+            navigate(to: SettingsPage(), mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
+        }
+    }
+
+    func tabViewItem(for tab: MainWindowTab) -> TabViewItem {
+        let id = ObjectIdentifier(tab)
+        if let item = tabItemsByID[id] {
+            return item
+        }
+
+        let item = TabViewItem()
+        let name = id.debugDescription
+        item.name = name
+        tabIDByName[name] = id
+        item.tapped.addHandler { [weak self, weak item] _, _ in
+            guard let self, let item, let tab = self.tab(for: item) else { return }
+            self.switchToTab(tab)
+        }
+        item.closeRequested.addHandler { [weak self, weak item] _, _ in
+            guard let self, let item else { return }
+            self.closeTab(for: item)
+        }
+        tabItemsByID[id] = item
+        updateTabItemState(for: tab)
+        return item
+    }
+
+    func updateTabItemState(for tab: MainWindowTab) {
+        let id = ObjectIdentifier(tab)
+        guard let item = tabItemsByID[id] else { return }
+
+        let newTitle = title(for: tab.currentPage)
+        if tabTitlesByID[id] != newTitle {
+            item.header = newTitle
+            tabTitlesByID[id] = newTitle
+        }
+
+        let canClose = viewModel.tabs.count > 1
+        if tabClosableByID[id] != canClose {
+            item.isClosable = canClose
+            tabClosableByID[id] = canClose
+        }
+    }
+
+    private func updateAllTabItemCloseStates() {
+        for tab in viewModel.tabs {
+            updateTabItemState(for: tab)
+        }
+    }
+
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Observation
+import WinAppSDK
+import WinUI
+
+extension MainWindow {
+    func setupWindow() {
+        self.extendsContentIntoTitleBar = true
+        self.appWindow.titleBar.preferredHeightOption = .tall
+                
+        // 设置 Mica 背景
+        let micaBackdrop = MicaBackdrop()
+        micaBackdrop.kind = .base
+        self.systemBackdrop = micaBackdrop
+
+        self.sizeChanged.addHandler { [weak self] _, _ in
+            self?.trackWindowSize()
+        }
+        self.closed.addHandler { [weak self] _, _ in
+            guard let self else { return }
+
+            // 先 cancel observation tasks，避免死窗口的 task 继续访问 self.appWindow / self.viewModel
+            self.envObservationTask?.cancel()
+            self.routeObservationTask?.cancel()
+            self.envObservationTask = nil
+            self.routeObservationTask = nil
+
+            // TODO: appWindow.changed事件不工作，此处窗口最大化时记录有缺陷。其实也可以不保存，恢复窗口在中间即可。
+            self.trackWindowPosition()
+            self.viewModel.windowLayout.navigationViewPaneOpen = self.navigationView.isPaneOpen
+            self.viewModel.windowLayout.navigationViewOpenPaneLength = self.navigationView.openPaneLength
+            self.viewModel = nil
+        }
+        restoreWindowRect()
+    }
+
+
+    func startObserving() {
+        let env = Observations {
+            (App.context.theme, App.context.language)
+        }
+        envObservationTask = Task { [weak self] in
+            for await _ in env {
+                await MainActor.run { [weak self] in
+                    self?.applyAppearance()
+                }
+            }
+        }
+
+        // viewModel 在 closed handler 里会被设为 nil（包括最大化最后一个 tab 的场景），
+        // 此处必须用 ?. 避免 IUO 强解包崩溃；renderSelectedTab 也会再做一次 nil 检查
+        let route = Observations {
+            self.viewModel?.navigationRevision ?? 0
+        }
+        routeObservationTask = Task { [weak self] in
+            for await _ in route {
+                await MainActor.run { [weak self] in
+                    guard let self, self.viewModel != nil else { return }
+                    self.renderSelectedTab()
+                }
+            }
+        }
+    }
+
+    private func applyAppearance() {
+        // 死窗口防御：closed handler 把 viewModel 置为 nil，此时 appWindow 也已失效（IUO → nil）
+        guard viewModel != nil, appWindow != nil else { return }
+        // 防止并发/重入（多窗口下 env Observation 接连触发可能引发 menuItems 的双 parent 错误）
+        guard !isApplyingAppearance else { return }
+        isApplyingAppearance = true
+        defer { isApplyingAppearance = false }
+
+        // For min/max/close buttons. 目前不支持材质效果，但比逐个设置按钮颜色简单，并且容易由框架修正。
+        self.appWindow.titleBar.preferredTheme = App.context.theme.titleBarTheme
+
+        self.title = MainWindow.tr(App.context.productName)
+        titleBar.title = self.title
+        searchBox?.placeholderText = MainWindow.tr("searchControlsAndSamples")
+
+        let context = WindowContext(owner: self)
+        titleBarRightHeader.children.clear()
+        navigationView.menuItems.clear()
+        navigationView.footerMenuItems.clear()
+        for module in App.context.modules {
+            if let item = module.titleBarRightHeaderItemRequired(in: context) {
+                titleBarRightHeader.children.append(item)
+            }
+            for item in module.navigationViewMenuItemsRequired(in: context) {
+                appendNavigationItem(item, false)
+            }
+            for item in module.navigationViewFooterMenuItemsRequired(in: context) {
+                appendNavigationItem(item, true)
+            }
+        }
+
+        if let url = initialNavigationURL {
+            initialNavigationURL = nil
+            _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
+            return
+        }
+
+        if let page = viewModel.currentPage {
+            navigate(to: page)
+        } else if let lastURL = viewModel.routePreferences.lastPageURL, navigate(to: lastURL) {
+            return
+        } else {
+            navigationView.selectFirstItem()
+        }
+    }
+    
+    private func restoreWindowRect() {
+        guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter
+        else { return }
+
+        let maximized = viewModel.windowPosition.isMaximized //moveAndResize will cause pref changed in event, so need to reserve here
+        try? hwnd.moveAndResize(viewModel.windowPosition.windowRect)
+        if maximized {
+            try? presenter.maximize()
+        }
+    }
+
+    private func trackWindowSize() {
+        guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter else { return }
+
+        if presenter.state == .restored {
+            viewModel.windowPosition.windowWidth = Int(hwnd.size.width)
+            viewModel.windowPosition.windowHeight = Int(hwnd.size.height)
+            viewModel.windowPosition.isMaximized = false
+        } else if presenter.state == .maximized {
+            viewModel.windowPosition.isMaximized = true
+        }
+    }
+
+    private func trackWindowPosition() {
+        guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter
+        else { return }
+
+        if presenter.state == .restored {
+            viewModel.windowPosition.windowX = Int(hwnd.position.x)
+            viewModel.windowPosition.windowY = Int(hwnd.position.y)
+        }
+    }
+
+    // MARK: - Splitter Methods
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -266,41 +266,77 @@ class MainWindow: Window {
         return transition
     }
 
-    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
-        let inNewTab = openInNewTabRequested
-        openInNewTabRequested = false
-        navigate(to: page, transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
+    func navigate(
+        to page: Page,
+        mode: NavigationOpenMode = .inplace,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) {
+        let effective = resolveOpenMode(mode)
+        performNavigate(to: page, mode: effective, transitionInfoOverride: transitionInfoOverride)
     }
 
-    private func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil, inNewTab: Bool) {
+    @discardableResult
+    func navigate(
+        to url: URL,
+        mode: NavigationOpenMode = .inplace,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Bool {
+        let effective = resolveOpenMode(mode)
+        return performNavigate(to: url, mode: effective, transitionInfoOverride: transitionInfoOverride)
+    }
+
+    /// NavigationViewItem 上 Ctrl+click 设置的 `openInNewTabRequested` 标记会把
+    /// `.inplace` 升级为 `.newTab`；调用者显式指定的非 inplace 模式不被覆盖。
+    private func resolveOpenMode(_ requested: NavigationOpenMode) -> NavigationOpenMode {
+        let flag = openInNewTabRequested
+        openInNewTabRequested = false
+        if requested == .inplace && flag {
+            return .newTab
+        }
+        return requested
+    }
+
+    private func performNavigate(
+        to page: Page,
+        mode: NavigationOpenMode,
+        transitionInfoOverride: NavigationTransitionInfo?
+    ) {
+        if mode == .newWindow {
+            MainWindow.openDetachedWindow(navigatingTo: page.url)
+            return
+        }
         viewModel.navigate(
             to: page,
             transitionInfoOverride: transitionInfoOverride,
-            inNewTab: inNewTab
+            inNewTab: mode != .inplace,
+            switchToTab: mode != .newTabBackground
         )
         renderSelectedTab()
     }
 
-    func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil) -> Bool {
-        let inNewTab = openInNewTabRequested
-        openInNewTabRequested = false
-        return navigate(to: url, transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
-    }
-
     @discardableResult
-    private func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil, inNewTab: Bool) -> Bool {
-        if !inNewTab, viewModel.currentPage?.url == url {
+    private func performNavigate(
+        to url: URL,
+        mode: NavigationOpenMode,
+        transitionInfoOverride: NavigationTransitionInfo?
+    ) -> Bool {
+        if mode == .newWindow {
+            MainWindow.openDetachedWindow(navigatingTo: url)
+            return true
+        }
+        // 仅在 inplace 模式下短路；其他模式（newTab / newTabBackground）允许重复打开同 URL
+        if mode == .inplace, viewModel.currentPage?.url == url {
             return true
         }
 
         if url == SettingsPage.url {
-            navigate(to: SettingsPage(), transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
+            performNavigate(to: SettingsPage(), mode: mode, transitionInfoOverride: transitionInfoOverride)
             return true
         } else {
             let context = WindowContext(owner: self)
             for module in App.context.modules {
                 if let page = module.navigationRequested(for: url, in: context) {
-                    navigate(to: page, transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
+                    performNavigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
                     return true
                 }
             }
@@ -436,7 +472,7 @@ class MainWindow: Window {
         tabView.drop.addHandler { [weak self] _, _ in
             guard let self else { return }
             guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
-            _ = self.navigate(to: drag.tabURL, transitionInfoOverride: SuppressNavigationTransitionInfo(), inNewTab: true)
+            _ = self.navigate(to: drag.tabURL, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
         }
 
         setupTabDragHint()
@@ -521,7 +557,7 @@ class MainWindow: Window {
         }
 
         let tabItem = tabViewItem(for: tab)
-        if tabView.selectedItem as? TabViewItem !== tabItem {
+        if !tabViewItem(tabView.selectedItem as? TabViewItem, represents: ObjectIdentifier(tab)) {
             isSyncingTabSelection = true
             tabView.selectedItem = tabItem
             isSyncingTabSelection = false
@@ -551,23 +587,56 @@ class MainWindow: Window {
         isSyncingTabSelection = true
         defer { isSyncingTabSelection = false }
 
-        while items.size > viewModel.tabs.count {
-            items.removeAt(items.size - 1)
+        // Step 1: 按身份精确移除 items 中所有不再属于 viewModel.tabs 的 TabViewItem。
+        //   旧版只 `items.removeAt(items.size - 1)` 截尾，关闭非末尾 tab 时残留错位 item，
+        //   后续 insertAt 会试图把同一 UIElement 插到已存在位置 → "two parents" WinRT 异常。
+        var i: UInt32 = 0
+        while i < items.size {
+            if let item = items.getAt(i) as? TabViewItem,
+               let id = tabIDByName[item.name],
+               activeIDs.contains(id) {
+                i += 1
+            } else {
+                items.removeAt(i)
+            }
         }
 
+        // Step 2: 重排到目标顺序。如果目标 tabItem 已在 items 中（错位），先从原位置移除再插入。
         for (index, tab) in viewModel.tabs.enumerated() {
+            let id = ObjectIdentifier(tab)
             let tabItem = tabViewItem(for: tab)
-            if UInt32(index) < items.size, let item = items.getAt(UInt32(index)) as? TabViewItem, item === tabItem {
+            if UInt32(index) < items.size,
+               let item = items.getAt(UInt32(index)) as? TabViewItem,
+               tabViewItem(item, represents: id) {
                 continue
             }
 
-            if UInt32(index) < items.size {
-                items.removeAt(UInt32(index))
+            // 找一下 tabItem 是否已在 items 别处
+            var existingIndex: UInt32? = nil
+            var j: UInt32 = 0
+            while j < items.size {
+                if let item = items.getAt(j) as? TabViewItem,
+                   tabViewItem(item, represents: id) {
+                    existingIndex = j
+                    break
+                }
+                j += 1
+            }
+            if let existingIndex {
+                items.removeAt(existingIndex)
             }
             items.insertAt(UInt32(index), tabItem)
         }
         tabStripIDs = ids
         updateAllTabItemCloseStates()
+    }
+
+    private func tabViewItem(_ item: TabViewItem?, represents id: ObjectIdentifier) -> Bool {
+        guard let item else { return false }
+        if tabIDByName[item.name] == id {
+            return true
+        }
+        return tabItemsByID[id] === item
     }
 
     private func updateTabStripVisibility() {
@@ -576,11 +645,9 @@ class MainWindow: Window {
 
     private func openNewTabFromTabStrip() {
         if let url = firstNavigationItemURL() {
-            openInNewTabRequested = true
-            _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
+            _ = navigate(to: url, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
         } else {
-            openInNewTabRequested = true
-            navigate(to: SettingsPage(), transitionInfoOverride: SuppressNavigationTransitionInfo())
+            navigate(to: SettingsPage(), mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
         }
     }
 
@@ -862,20 +929,29 @@ class MainWindow: Window {
     /// 这种异常发生在 COM callback 路径里，会从 `try!` 抛出但传不到 Swift 主线程，
     /// 进程不会真正终止，但相关 UI 操作会失败、日志会污染。
     private static func safelyAssignChild(_ child: UIElement, toBorder border: Border) {
-        if let parent = try? VisualTreeHelper.getParent(child) {
-            if let parentBorder = parent as? Border {
-                parentBorder.child = nil
-            } else if let parentPanel = parent as? Panel {
-                var idx: UInt32 = 0
-                if parentPanel.children.indexOf(child, &idx) {
-                    parentPanel.children.removeAt(idx)
-                }
-            } else if let parentContent = parent as? ContentControl {
-                parentContent.content = nil
-            }
-            // 其他 parent 类型暂不处理；如有需要后续可扩展
-        }
+        detachFromVisualParent(child)
         border.child = child
+    }
+
+    /// 把 element 从其当前 visual parent 上断开。覆盖 Border / Panel / ContentControl /
+    /// ContentPresenter 这几种最常见的 parent 类型。其他类型（如 ItemsControl 直接挂载
+    /// arbitrary UIElement，理论上不应该出现）打日志方便排查。
+    private static func detachFromVisualParent(_ element: UIElement) {
+        guard let parent = try? VisualTreeHelper.getParent(element) else { return }
+        if let parentBorder = parent as? Border {
+            parentBorder.child = nil
+        } else if let parentPanel = parent as? Panel {
+            var idx: UInt32 = 0
+            if parentPanel.children.indexOf(element, &idx) {
+                parentPanel.children.removeAt(idx)
+            }
+        } else if let parentContent = parent as? ContentControl {
+            parentContent.content = nil
+        } else if let parentPresenter = parent as? ContentPresenter {
+            parentPresenter.content = nil
+        } else {
+            print("[RsUI] detachFromVisualParent: unsupported parent type \(type(of: parent)) for child \(type(of: element)) — 'Element is already the child of another element' may follow")
+        }
     }
 
     private func syncNavigationSelection(for url: URL) {
@@ -916,8 +992,8 @@ class MainWindow: Window {
             guard let self else { return }
             _ = self.navigate(
                 to: url,
-                transitionInfoOverride: SuppressNavigationTransitionInfo(),
-                inNewTab: true
+                mode: .newTab,
+                transitionInfoOverride: SuppressNavigationTransitionInfo()
             )
         }) ?? false
 
@@ -926,8 +1002,8 @@ class MainWindow: Window {
                 guard let self else { return }
                 _ = self.navigate(
                     to: url,
-                    transitionInfoOverride: SuppressNavigationTransitionInfo(),
-                    inNewTab: true
+                    mode: .newTab,
+                    transitionInfoOverride: SuppressNavigationTransitionInfo()
                 )
             }
         }

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -86,6 +86,37 @@ class MainWindow: Window {
         self.viewModel.goForward(MainWindow.makeSlideTransition(effect: .fromRight))
         self.renderSelectedTab()
     }
+    private lazy var closeOtherTabsButton: Button = {
+        let icon = FontIcon()
+        icon.glyph = "\u{E8BB}"
+        icon.fontSize = 12
+        let btn = Button()
+        btn.content = icon
+        btn.width = 28
+        btn.height = 28
+        btn.minWidth = 0
+        btn.minHeight = 0
+        btn.margin = Thickness(left: 4, top: 0, right: 4, bottom: 0)
+        btn.verticalAlignment = .center
+        btn.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)
+        btn.allowFocusOnInteraction = false
+        let transparent = SolidColorBrush(Colors.transparent)
+        let hoverBrush = SolidColorBrush(UWP.Color(a: 0x18, r: 0x80, g: 0x80, b: 0x80))
+        let pressedBrush = SolidColorBrush(UWP.Color(a: 0x30, r: 0x80, g: 0x80, b: 0x80))
+        for key in ["ButtonBackground", "ButtonBackgroundDisabled"] {
+            _ = btn.resources.insert(key, transparent)
+        }
+        _ = btn.resources.insert("ButtonBackgroundPointerOver", hoverBrush)
+        _ = btn.resources.insert("ButtonBackgroundPressed", pressedBrush)
+        for key in ["ButtonBorderBrush", "ButtonBorderBrushPointerOver",
+                    "ButtonBorderBrushPressed", "ButtonBorderBrushDisabled"] {
+            _ = btn.resources.insert(key, transparent)
+        }
+        btn.click.addHandler { [weak self] _, _ in
+            self?.closeOtherTabs()
+        }
+        return btn
+    }()
     private lazy var searchBox: AutoSuggestBox? = {
         // let box = AutoSuggestBox()
         // box.width = 360
@@ -144,6 +175,9 @@ class MainWindow: Window {
         tabs.isAddTabButtonVisible = true
         tabs.tabWidthMode = .equal
         tabs.closeButtonOverlayMode = .onPointerOver
+        tabs.tabStripHeader = closeOtherTabsButton
+        tabs.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)
+        tabs.margin = Thickness(left: 0, top: -1, right: 0, bottom: 0)
         return tabs
     } ()
     private lazy var tabContentHost = Grid()
@@ -185,7 +219,8 @@ class MainWindow: Window {
         nav.compactModeThresholdWidth = 0
         nav.expandedModeThresholdWidth = length + viewModel.windowLayout.navigationViewExpandedModeThresholdContentWidth
         nav.isPaneOpen = viewModel.windowLayout.navigationViewPaneOpen
-        nav.openPaneLength = length        
+        nav.openPaneLength = length
+        nav.isTitleBarAutoPaddingEnabled = false
         nav.content = navigationContentRoot
 
         return nav
@@ -589,6 +624,11 @@ class MainWindow: Window {
         renderSelectedTab()
     }
 
+    private func closeOtherTabs() {
+        viewModel.closeOtherTabs()
+        renderSelectedTab()
+    }
+
     private func firstNavigationItemURL() -> URL? {
         return firstNavigationItemURL(in: navigationView.menuItems)
             ?? firstNavigationItemURL(in: navigationView.footerMenuItems)
@@ -632,7 +672,8 @@ class MainWindow: Window {
         parts.headerBorder = nil
         tabPageViewPartsByID[tabID] = parts
 
-        guard let header = page.header else {
+        // String headers are shown as tab titles; only UIElement headers are rendered inline
+        guard let view = page.header as? UIElement else {
             return page.content
         }
 
@@ -644,22 +685,10 @@ class MainWindow: Window {
         grid.rowDefinitions.append(autoRow)
         grid.rowDefinitions.append(starRow)
 
-        // Row 0: header, margin matches NavigationViewHeaderMargin (56,44,0,0)
+        // Row 0: UIElement header (no legacy NavigationView margin needed)
         let headerBorder = Border()
-        headerBorder.margin = Thickness(left: 56, top: 44, right: 0, bottom: 0)
-        if let text = header as? String {
-            let tb = TextBlock()
-            tb.text = text
-            tb.fontSize = 28
-            tb.fontWeight = FontWeights.semiBold
-            tb.textWrapping = .wrap
-            headerBorder.child = tb
-        } else if let view = header as? UIElement {
-            headerBorder.child = view
-            parts.headerBorder = headerBorder
-        } else {
-            return page.content
-        }
+        headerBorder.child = view
+        parts.headerBorder = headerBorder
 
         // Row 1: content
         let contentBorder = Border()

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -799,8 +799,19 @@ class MainWindow: Window {
         parts.headerBorder = nil
         tabPageViewPartsByID[tabID] = parts
 
-        // String headers are shown as tab titles; only UIElement headers are rendered inline
-        guard let view = page.header as? UIElement else {
+        // String header → 同时渲染为页面顶部 28pt 大标题 + 通过 title(for:) 用作 Tab 标签
+        // UIElement header → 直接渲染到页面顶部
+        let headerView: UIElement
+        if let text = page.header as? String {
+            let tb = TextBlock()
+            tb.text = text
+            tb.fontSize = 28
+            tb.fontWeight = FontWeights.semiBold
+            tb.textWrapping = .wrap
+            headerView = tb
+        } else if let view = page.header as? UIElement {
+            headerView = view
+        } else {
             return page.content
         }
 
@@ -812,9 +823,10 @@ class MainWindow: Window {
         grid.rowDefinitions.append(autoRow)
         grid.rowDefinitions.append(starRow)
 
-        // Row 0: UIElement header (no legacy NavigationView margin needed)
+        // Row 0: header — margin matches WinUI default NavigationViewHeaderMargin (56,44,0,0)
         let headerBorder = Border()
-        headerBorder.child = view
+        headerBorder.margin = Thickness(left: 56, top: 44, right: 0, bottom: 0)
+        headerBorder.child = headerView
         parts.headerBorder = headerBorder
 
         // Row 1: content

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -92,13 +92,14 @@ class MainWindow: Window {
         icon.fontSize = 12
         let btn = Button()
         btn.content = icon
-        btn.width = 28
-        btn.height = 28
         btn.minWidth = 0
         btn.minHeight = 0
-        btn.margin = Thickness(left: 4, top: 0, right: 4, bottom: 0)
-        btn.verticalAlignment = .center
-        btn.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)
+        // Match TabViewItem: OverlayCornerRadius=8, padding matching TabViewItemHeaderPadding
+        btn.cornerRadius = CornerRadius(topLeft: 8, topRight: 8, bottomRight: 8, bottomLeft: 8)
+        btn.padding = Thickness(left: 10, top: 0, right: 10, bottom: 0)
+        // 4px top/bottom margin to sit within strip like tab items; 2px right keeps it tight to first tab
+        btn.margin = Thickness(left: 4, top: 4, right: 2, bottom: 4)
+        btn.verticalAlignment = .stretch
         btn.allowFocusOnInteraction = false
         let transparent = SolidColorBrush(Colors.transparent)
         let hoverBrush = SolidColorBrush(UWP.Color(a: 0x18, r: 0x80, g: 0x80, b: 0x80))
@@ -115,6 +116,9 @@ class MainWindow: Window {
         btn.click.addHandler { [weak self] _, _ in
             self?.closeOtherTabs()
         }
+        let toolTip = ToolTip()
+        toolTip.content = tr("关闭其他标签")
+        try? ToolTipService.setToolTip(btn, toolTip)
         return btn
     }()
     private lazy var searchBox: AutoSuggestBox? = {

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -23,10 +23,16 @@ fileprivate extension WindowPosition {
 }
 
 /// 主窗口类，管理整个应用的导航和 UI 布局
+private final class PageViewParts {
+    var contentBorder: Border?
+    var headerBorder: Border?
+}
+
 class MainWindow: Window {
     // MARK: - 属性
     private var viewModel: MainWindowViewModel! = MainWindowViewModel()
     private var isSyncingSelection = false
+    private var isSyncingTabSelection = false
 
     // Splitter state
     private var splitterBorder: Border!
@@ -71,10 +77,14 @@ class MainWindow: Window {
     }
 
     private lazy var backButton: Button = MainWindow.makeNavButton(glyph: "\u{E72B}") { [weak self] in
-        self?.viewModel.goBack(MainWindow.makeSlideTransition(effect: .fromLeft))
+        guard let self else { return }
+        self.viewModel.goBack(MainWindow.makeSlideTransition(effect: .fromLeft))
+        self.renderSelectedTab()
     }
     private lazy var forwardButton: Button = MainWindow.makeNavButton(glyph: "\u{E72A}") { [weak self] in
-        self?.viewModel.goForward(MainWindow.makeSlideTransition(effect: .fromRight))
+        guard let self else { return }
+        self.viewModel.goForward(MainWindow.makeSlideTransition(effect: .fromRight))
+        self.renderSelectedTab()
     }
     private lazy var searchBox: AutoSuggestBox? = {
         // let box = AutoSuggestBox()
@@ -129,9 +139,39 @@ class MainWindow: Window {
 
         return bar
     } ()
-    private lazy var navigationContentFrame = PageTransitionHost()
-    private var pageViewContentBorder: Border?
-    private var pageViewHeaderBorder: Border?
+    private lazy var tabView: TabView = {
+        let tabs = TabView()
+        tabs.isAddTabButtonVisible = true
+        tabs.tabWidthMode = .equal
+        tabs.closeButtonOverlayMode = .onPointerOver
+        return tabs
+    } ()
+    private lazy var tabContentHost = Grid()
+    private lazy var navigationContentRoot: Grid = {
+        let grid = Grid()
+
+        let tabRow = RowDefinition()
+        tabRow.height = GridLength(value: 1, gridUnitType: .auto)
+        let contentRow = RowDefinition()
+        contentRow.height = GridLength(value: 1, gridUnitType: .star)
+        grid.rowDefinitions.append(tabRow)
+        grid.rowDefinitions.append(contentRow)
+
+        grid.children.append(tabView)
+        try? Grid.setRow(tabView, 0)
+
+        grid.children.append(tabContentHost)
+        try? Grid.setRow(tabContentHost, 1)
+
+        return grid
+    } ()
+    private var tabItemsByID: [ObjectIdentifier: TabViewItem] = [:]
+    private var tabFramesByID: [ObjectIdentifier: PageTransitionHost] = [:]
+    private var tabPageViewPartsByID: [ObjectIdentifier: PageViewParts] = [:]
+    private var tabStripIDs: [ObjectIdentifier] = []
+    private var tabTitlesByID: [ObjectIdentifier: String] = [:]
+    private var tabClosableByID: [ObjectIdentifier: Bool] = [:]
+    private var visibleTabFrameID: ObjectIdentifier?
     private var isFirstNavigation = true
     private lazy var navigationView = {
         let nav = NavigationView()
@@ -146,7 +186,7 @@ class MainWindow: Window {
         nav.expandedModeThresholdWidth = length + viewModel.windowLayout.navigationViewExpandedModeThresholdContentWidth
         nav.isPaneOpen = viewModel.windowLayout.navigationViewPaneOpen
         nav.openPaneLength = length        
-        nav.content = navigationContentFrame
+        nav.content = navigationContentRoot
 
         return nav
     } ()
@@ -168,18 +208,40 @@ class MainWindow: Window {
     }
 
     func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
-        viewModel.navigate(to: page, transitionInfoOverride: transitionInfoOverride)
+        let inNewTab = openInNewTabRequested
+        openInNewTabRequested = false
+        navigate(to: page, transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
+    }
+
+    private func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil, inNewTab: Bool) {
+        viewModel.navigate(
+            to: page,
+            transitionInfoOverride: transitionInfoOverride,
+            inNewTab: inNewTab
+        )
+        renderSelectedTab()
     }
 
     func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil) -> Bool {
+        let inNewTab = openInNewTabRequested
+        openInNewTabRequested = false
+        return navigate(to: url, transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
+    }
+
+    @discardableResult
+    private func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil, inNewTab: Bool) -> Bool {
+        if !inNewTab, viewModel.currentPage?.url == url {
+            return true
+        }
+
         if url == SettingsPage.url {
-            navigate(to: SettingsPage(), transitionInfoOverride: transitionInfoOverride)
+            navigate(to: SettingsPage(), transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
             return true
         } else {
             let context = WindowContext(owner: self)
             for module in App.context.modules {
                 if let page = module.navigationRequested(for: url, in: context) {
-                    navigate(to: page, transitionInfoOverride: transitionInfoOverride)
+                    navigate(to: page, transitionInfoOverride: transitionInfoOverride, inNewTab: inNewTab)
                     return true
                 }
             }
@@ -233,14 +295,30 @@ class MainWindow: Window {
             guard let self, let args, !self.isSyncingSelection else { return }
 
             if args.isSettingsSelected {
-                navigate(to: SettingsPage(), transitionInfoOverride: args.recommendedNavigationTransitionInfo)
+                navigate(to: SettingsPage(), transitionInfoOverride: SuppressNavigationTransitionInfo())
             } else if
                 let item = args.selectedItem as? NavigationViewItem,
                 let tag = item.tag,
                 let str = tag as? HString,
                 let url = URL(string: String(hString: str)) {
-                _ = navigate(to: url, transitionInfoOverride: args.recommendedNavigationTransitionInfo)
+                _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
             }
+        }
+
+        tabView.selectionChanged.addHandler { [weak self] sender, args in
+            guard let self, !self.isSyncingTabSelection else { return }
+            guard let item = self.selectedTabViewItem(sender: sender, args: args) else { return }
+            guard let tab = self.tab(for: item) else { return }
+            self.switchToTab(tab)
+        }
+
+        tabView.tabCloseRequested.addHandler { [weak self] _, args in
+            guard let self, let args, let item = args.tab else { return }
+            self.closeTab(for: item)
+        }
+
+        tabView.addTabButtonClick.addHandler { [weak self] _, _ in
+            self?.openNewTabFromTabStrip()
         }
 
         navigationView.paneClosed.addHandler { [weak self] _, _ in
@@ -276,48 +354,283 @@ class MainWindow: Window {
         }
 
         let route = Observations {
-            self.viewModel.currentPage
+            self.viewModel.navigationRevision
         }
         Task { [weak self] in
             for await _ in route {
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
-
-                    if let page = self.viewModel.currentPage {
-                        self.navigationView.header = nil
-                        let effectiveTransitionInfo: NavigationTransitionInfo?
-                        if isFirstNavigation {
-                            effectiveTransitionInfo = SuppressNavigationTransitionInfo()
-                            isFirstNavigation = false
-                        } else {
-                            effectiveTransitionInfo = self.viewModel.navigationTransitionInfo
-                        }
-                        self.navigationContentFrame.transition(
-                            to: self.makePageView(page),
-                            transitionInfo: effectiveTransitionInfo
-                        )
-                        self.syncNavigationSelection(for: page.url)
-                    } else {
-                        self.navigationView.header = nil
-                        self.navigationContentFrame.transition(
-                            to: nil,
-                            transitionInfo: self.viewModel.navigationTransitionInfo
-                        )
-                        self.navigationView.selectedItem = nil
-                    }
-                    
-                    self.backButton.isEnabled = !self.viewModel.backwardPages.isEmpty
-                    self.forwardButton.isEnabled = !self.viewModel.forwardPages.isEmpty
+                    self?.renderSelectedTab()
                 }
             }
         }
     }
 
-    private func makePageView(_ page: Page) -> UIElement {
-        pageViewContentBorder?.child = nil
-        pageViewHeaderBorder?.child = nil
-        pageViewContentBorder = nil
-        pageViewHeaderBorder = nil
+    private func renderSelectedTab() {
+        syncTabItems()
+        updateTabStripVisibility()
+
+        guard let tab = viewModel.selectedTab, let page = tab.currentPage else {
+            navigationView.header = nil
+            hideAllTabFrames()
+            navigationView.selectedItem = nil
+            backButton.isEnabled = false
+            forwardButton.isEnabled = false
+            return
+        }
+
+        navigationView.header = nil
+        updateTabItemState(for: tab)
+        let frame = showFrame(for: tab)
+
+        if tab.needsRender {
+            let effectiveTransitionInfo: NavigationTransitionInfo?
+            if isFirstNavigation {
+                effectiveTransitionInfo = SuppressNavigationTransitionInfo()
+                isFirstNavigation = false
+            } else {
+                effectiveTransitionInfo = tab.navigationTransitionInfo
+            }
+            frame.transition(
+                to: makePageView(page, for: tab),
+                transitionInfo: effectiveTransitionInfo
+            )
+            tab.needsRender = false
+        }
+
+        let tabItem = tabViewItem(for: tab)
+        if tabView.selectedItem as? TabViewItem !== tabItem {
+            isSyncingTabSelection = true
+            tabView.selectedItem = tabItem
+            isSyncingTabSelection = false
+        }
+
+        syncNavigationSelection(for: page.url)
+        backButton.isEnabled = !tab.backwardPages.isEmpty
+        forwardButton.isEnabled = !tab.forwardPages.isEmpty
+    }
+
+    private func syncTabItems() {
+        guard let items = tabView.tabItems else { return }
+
+        let ids = viewModel.tabs.map { ObjectIdentifier($0) }
+        let activeIDs = Set(ids)
+        tabItemsByID = tabItemsByID.filter { activeIDs.contains($0.key) }
+        tabTitlesByID = tabTitlesByID.filter { activeIDs.contains($0.key) }
+        tabClosableByID = tabClosableByID.filter { activeIDs.contains($0.key) }
+        tabPageViewPartsByID = tabPageViewPartsByID.filter { activeIDs.contains($0.key) }
+        removeClosedTabFrames(activeIDs: activeIDs)
+
+        guard ids != tabStripIDs else {
+            return
+        }
+
+        while items.size > viewModel.tabs.count {
+            items.removeAt(items.size - 1)
+        }
+
+        for (index, tab) in viewModel.tabs.enumerated() {
+            let tabItem = tabViewItem(for: tab)
+            if UInt32(index) < items.size, let item = items.getAt(UInt32(index)) as? TabViewItem, item === tabItem {
+                continue
+            }
+
+            if UInt32(index) < items.size {
+                items.removeAt(UInt32(index))
+            }
+            items.insertAt(UInt32(index), tabItem)
+        }
+        tabStripIDs = ids
+        updateAllTabItemCloseStates()
+    }
+
+    private func updateTabStripVisibility() {
+        tabView.visibility = viewModel.tabs.count <= 1 ? .collapsed : .visible
+    }
+
+    private func openNewTabFromTabStrip() {
+        if let url = firstNavigationItemURL() {
+            openInNewTabRequested = true
+            _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
+        } else {
+            openInNewTabRequested = true
+            navigate(to: SettingsPage(), transitionInfoOverride: SuppressNavigationTransitionInfo())
+        }
+    }
+
+    private func tabViewItem(for tab: MainWindowTab) -> TabViewItem {
+        let id = ObjectIdentifier(tab)
+        if let item = tabItemsByID[id] {
+            return item
+        }
+
+        let item = TabViewItem()
+        item.tapped.addHandler { [weak self, weak item] _, _ in
+            guard let self, let item, let tab = self.tab(for: item) else { return }
+            self.switchToTab(tab)
+        }
+        item.closeRequested.addHandler { [weak self, weak item] _, _ in
+            guard let self, let item else { return }
+            self.closeTab(for: item)
+        }
+        tabItemsByID[id] = item
+        updateTabItemState(for: tab)
+        return item
+    }
+
+    private func updateTabItemState(for tab: MainWindowTab) {
+        let id = ObjectIdentifier(tab)
+        guard let item = tabItemsByID[id] else { return }
+
+        let newTitle = title(for: tab.currentPage)
+        if tabTitlesByID[id] != newTitle {
+            item.header = newTitle
+            tabTitlesByID[id] = newTitle
+        }
+
+        let canClose = viewModel.tabs.count > 1
+        if tabClosableByID[id] != canClose {
+            item.isClosable = canClose
+            tabClosableByID[id] = canClose
+        }
+    }
+
+    private func updateAllTabItemCloseStates() {
+        for tab in viewModel.tabs {
+            updateTabItemState(for: tab)
+        }
+    }
+
+    private func frame(for tab: MainWindowTab) -> PageTransitionHost {
+        let id = ObjectIdentifier(tab)
+        if let frame = tabFramesByID[id] {
+            return frame
+        }
+
+        let frame = PageTransitionHost()
+        frame.visibility = .collapsed
+        tabFramesByID[id] = frame
+        tabContentHost.children.append(frame)
+        return frame
+    }
+
+    private func showFrame(for tab: MainWindowTab) -> PageTransitionHost {
+        let id = ObjectIdentifier(tab)
+        let selectedFrame = frame(for: tab)
+        guard visibleTabFrameID != id else {
+            return selectedFrame
+        }
+
+        for (frameID, frame) in tabFramesByID {
+            frame.visibility = frameID == id ? .visible : .collapsed
+        }
+        visibleTabFrameID = id
+        return selectedFrame
+    }
+
+    private func hideAllTabFrames() {
+        for frame in tabFramesByID.values {
+            frame.visibility = .collapsed
+        }
+        visibleTabFrameID = nil
+    }
+
+    private func removeClosedTabFrames(activeIDs: Set<ObjectIdentifier>) {
+        let closedIDs = tabFramesByID.keys.filter { !activeIDs.contains($0) }
+        for id in closedIDs {
+            guard let frame = tabFramesByID.removeValue(forKey: id) else { continue }
+            removeTabFrame(frame)
+            if visibleTabFrameID == id {
+                visibleTabFrameID = nil
+            }
+        }
+    }
+
+    private func removeTabFrame(_ frame: PageTransitionHost) {
+        var idx: UInt32 = 0
+        if tabContentHost.children.indexOf(frame, &idx) {
+            tabContentHost.children.removeAt(idx)
+        }
+    }
+
+    private func tab(for item: TabViewItem) -> MainWindowTab? {
+        for tab in viewModel.tabs {
+            if tabItemsByID[ObjectIdentifier(tab)] === item {
+                return tab
+            }
+        }
+        return nil
+    }
+
+    private func selectedTabViewItem(sender: Any?, args: SelectionChangedEventArgs?) -> TabViewItem? {
+        if
+            let args,
+            let addedItems = args.addedItems,
+            addedItems.size > 0,
+            let item = addedItems.getAt(0) as? TabViewItem {
+            return item
+        }
+
+        if let tabView = sender as? TabView {
+            return tabView.selectedItem as? TabViewItem
+        }
+
+        return tabView.selectedItem as? TabViewItem
+    }
+
+    private func switchToTab(_ tab: MainWindowTab) {
+        guard viewModel.selectedTab !== tab else { return }
+        viewModel.select(tab: tab)
+        renderSelectedTab()
+    }
+
+    private func closeTab(for item: TabViewItem) {
+        guard let tab = tab(for: item) else { return }
+        viewModel.close(tab: tab)
+        renderSelectedTab()
+    }
+
+    private func firstNavigationItemURL() -> URL? {
+        return firstNavigationItemURL(in: navigationView.menuItems)
+            ?? firstNavigationItemURL(in: navigationView.footerMenuItems)
+    }
+
+    private func firstNavigationItemURL(in items: AnyIVector<Any?>?) -> URL? {
+        guard let items else { return nil }
+
+        for item in items {
+            guard let navItem = item as? NavigationViewItem else { continue }
+            if
+                let tag = navItem.tag,
+                let str = tag as? HString,
+                let url = URL(string: String(hString: str)) {
+                return url
+            }
+            if let url = firstNavigationItemURL(in: navItem.menuItems) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    private func title(for page: Page?) -> String {
+        guard let page else { return tr("New Tab") }
+        if let text = page.header as? String, !text.isEmpty {
+            return text
+        }
+
+        let host = page.url.host ?? page.url.absoluteString
+        return host.isEmpty ? page.url.absoluteString : host
+    }
+
+    private func makePageView(_ page: Page, for tab: MainWindowTab) -> UIElement {
+        let tabID = ObjectIdentifier(tab)
+        let parts = tabPageViewPartsByID[tabID] ?? PageViewParts()
+        parts.contentBorder?.child = nil
+        parts.headerBorder?.child = nil
+        parts.contentBorder = nil
+        parts.headerBorder = nil
+        tabPageViewPartsByID[tabID] = parts
 
         guard let header = page.header else {
             return page.content
@@ -343,7 +656,7 @@ class MainWindow: Window {
             headerBorder.child = tb
         } else if let view = header as? UIElement {
             headerBorder.child = view
-            pageViewHeaderBorder = headerBorder
+            parts.headerBorder = headerBorder
         } else {
             return page.content
         }
@@ -351,7 +664,7 @@ class MainWindow: Window {
         // Row 1: content
         let contentBorder = Border()
         contentBorder.child = page.content
-        pageViewContentBorder = contentBorder
+        parts.contentBorder = contentBorder
 
         try? Grid.setRow(headerBorder, 0)
         try? Grid.setRow(contentBorder, 1)
@@ -371,18 +684,65 @@ class MainWindow: Window {
         guard let args = args else { return }
         let rawValue = Int(args.keyModifiers.rawValue)
         openInNewTabRequested = (rawValue & 0x1) != 0
-        print("ctrl was \((openInNewTabRequested ?? false) ? "" : "not") pressed when navigationView was clicked")
+        print("ctrl was \(openInNewTabRequested ? "" : "not") pressed when navigationView was clicked")
     }
 
     private func appendNavigationItem(_ item: NavigationViewItemBase, _ isFooter: Bool) {
-        item.pointerPressed.addHandler { [weak self] _, args in
-            self?.captureOpenInNewTabRequested(args)
+        item.pointerPressed.addHandler { [weak self, weak item] _, args in
+            guard let self else { return }
+            self.captureOpenInNewTabRequested(args)
+            guard self.openInNewTabRequested, let item else { return }
+            self.openSelectedNavigationItemInNewTabIfNeeded(item, args)
         }
         if isFooter {
             navigationView.footerMenuItems.append(item)
         } else {
             navigationView.menuItems.append(item)
         }
+    }
+
+    private func openSelectedNavigationItemInNewTabIfNeeded(_ item: NavigationViewItemBase, _ args: PointerRoutedEventArgs?) {
+        guard isNavigationItemSelected(item), let url = url(for: item) else { return }
+
+        args?.handled = true
+        openInNewTabRequested = false
+
+        let queued = (try? dispatcherQueue?.tryEnqueue { [weak self] in
+            guard let self else { return }
+            _ = self.navigate(
+                to: url,
+                transitionInfoOverride: SuppressNavigationTransitionInfo(),
+                inNewTab: true
+            )
+        }) ?? false
+
+        if !queued {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                _ = self.navigate(
+                    to: url,
+                    transitionInfoOverride: SuppressNavigationTransitionInfo(),
+                    inNewTab: true
+                )
+            }
+        }
+    }
+
+    private func isNavigationItemSelected(_ item: NavigationViewItemBase) -> Bool {
+        guard let selectedItem = navigationView.selectedItem as? NavigationViewItemBase else { return false }
+        return selectedItem === item
+    }
+
+    private func url(for item: NavigationViewItemBase) -> URL? {
+        guard
+            let navItem = item as? NavigationViewItem,
+            let tag = navItem.tag,
+            let str = tag as? HString
+        else {
+            return nil
+        }
+
+        return URL(string: String(hString: str))
     }
 
     private func applyAppearance() {

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -42,6 +42,8 @@ class MainWindow: Window {
     private let splitterWidth: Double = 6
 
     private var openInNewTabRequested: Bool = false
+    private var initialNavigationURL: URL? = nil
+    private var tabDragHintBorder: Border? = nil
 
     /// UI 主要组件
     private static func makeNavButton(glyph: String, action: @escaping () -> Void) -> Button {
@@ -182,6 +184,8 @@ class MainWindow: Window {
         tabs.tabStripHeader = closeOtherTabsButton
         tabs.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)
         tabs.margin = Thickness(left: 0, top: -1, right: 0, bottom: 0)
+        tabs.canDragTabs = true
+        tabs.canReorderTabs = true
         return tabs
     } ()
     private lazy var tabContentHost = Grid()
@@ -204,6 +208,8 @@ class MainWindow: Window {
         return grid
     } ()
     private var tabItemsByID: [ObjectIdentifier: TabViewItem] = [:]
+    // Stable string name keyed to tab identity — avoids WinRT projection object identity instability
+    private var tabIDByName: [String: ObjectIdentifier] = [:]
     private var tabFramesByID: [ObjectIdentifier: PageTransitionHost] = [:]
     private var tabPageViewPartsByID: [ObjectIdentifier: PageViewParts] = [:]
     private var tabStripIDs: [ObjectIdentifier] = []
@@ -360,6 +366,31 @@ class MainWindow: Window {
             self?.openNewTabFromTabStrip()
         }
 
+        tabView.tabDroppedOutside.addHandler { [weak self] _, args in
+            print("[TabDrag] tabDroppedOutside fired, args=\(String(describing: args)), tab=\(String(describing: args?.tab))")
+            guard let self, let args, let item = args.tab else {
+                print("[TabDrag] guard failed: self=\(self != nil), args=\(args != nil)")
+                return
+            }
+            guard let tab = self.tab(for: item) else {
+                print("[TabDrag] tab(for:) returned nil for item.name=\(item.name), tabIDByName=\(self.tabIDByName.keys.joined(separator: ","))")
+                return
+            }
+            guard self.viewModel.tabs.count > 1 else {
+                print("[TabDrag] only 1 tab, skipping detach")
+                return
+            }
+            let url = tab.currentPage?.url
+            print("[TabDrag] detaching tab, navigating new window to \(url?.absoluteString ?? "nil")")
+            self.viewModel.close(tab: tab)
+            self.renderSelectedTab()
+            if let url {
+                MainWindow.openDetachedWindow(navigatingTo: url)
+            }
+        }
+
+        setupTabDragHint()
+
         navigationView.paneClosed.addHandler { [weak self] _, _ in
             self?.splitterBorder.visibility = .collapsed
         }
@@ -454,6 +485,7 @@ class MainWindow: Window {
         let ids = viewModel.tabs.map { ObjectIdentifier($0) }
         let activeIDs = Set(ids)
         tabItemsByID = tabItemsByID.filter { activeIDs.contains($0.key) }
+        tabIDByName = tabIDByName.filter { activeIDs.contains($0.value) }
         tabTitlesByID = tabTitlesByID.filter { activeIDs.contains($0.key) }
         tabClosableByID = tabClosableByID.filter { activeIDs.contains($0.key) }
         tabPageViewPartsByID = tabPageViewPartsByID.filter { activeIDs.contains($0.key) }
@@ -503,6 +535,9 @@ class MainWindow: Window {
         }
 
         let item = TabViewItem()
+        let name = id.debugDescription
+        item.name = name
+        tabIDByName[name] = id
         item.tapped.addHandler { [weak self, weak item] _, _ in
             guard let self, let item, let tab = self.tab(for: item) else { return }
             self.switchToTab(tab)
@@ -592,6 +627,11 @@ class MainWindow: Window {
     }
 
     private func tab(for item: TabViewItem) -> MainWindowTab? {
+        // Primary: stable name-based lookup (avoids WinRT projection identity instability)
+        if let id = tabIDByName[item.name], let tab = viewModel.tabs.first(where: { ObjectIdentifier($0) == id }) {
+            return tab
+        }
+        // Fallback: identity comparison
         for tab in viewModel.tabs {
             if tabItemsByID[ObjectIdentifier(tab)] === item {
                 return tab
@@ -631,6 +671,47 @@ class MainWindow: Window {
     private func closeOtherTabs() {
         viewModel.closeOtherTabs()
         renderSelectedTab()
+    }
+
+    private func setupTabDragHint() {
+        let hintText = TextBlock()
+        hintText.text = tr("拖动标签到窗口外，释放可分离为独立窗口")
+        hintText.fontSize = 12
+        hintText.textWrapping = .wrap
+        hintText.maxWidth = 460
+        hintText.foreground = SolidColorBrush(UWP.Color(a: 255, r: 245, g: 249, b: 255))
+
+        let hintBorder = Border()
+        hintBorder.background = SolidColorBrush(UWP.Color(a: 230, r: 21, g: 94, b: 175))
+        hintBorder.borderBrush = SolidColorBrush(UWP.Color(a: 255, r: 166, g: 215, b: 255))
+        hintBorder.borderThickness = Thickness(left: 1, top: 1, right: 1, bottom: 1)
+        hintBorder.cornerRadius = CornerRadius(topLeft: 10, topRight: 10, bottomRight: 10, bottomLeft: 10)
+        hintBorder.padding = Thickness(left: 12, top: 8, right: 12, bottom: 8)
+        hintBorder.horizontalAlignment = .center
+        hintBorder.verticalAlignment = .top
+        hintBorder.margin = Thickness(left: 0, top: 12, right: 0, bottom: 0)
+        hintBorder.opacity = 0
+        hintBorder.visibility = .collapsed
+        hintBorder.isHitTestVisible = false
+        hintBorder.child = hintText
+        try? Canvas.setZIndex(hintBorder, 99)
+        tabContentHost.children.append(hintBorder)
+        tabDragHintBorder = hintBorder
+
+        tabView.tabDragStarting.addHandler { [weak hintBorder] _, _ in
+            hintBorder?.visibility = .visible
+            hintBorder?.opacity = 1
+        }
+        tabView.tabDragCompleted.addHandler { [weak hintBorder] _, _ in
+            hintBorder?.opacity = 0
+            hintBorder?.visibility = .collapsed
+        }
+    }
+
+    static func openDetachedWindow(navigatingTo url: URL) {
+        let window = MainWindow()
+        window.initialNavigationURL = url
+        try? window.activate()
     }
 
     private func firstNavigationItemURL() -> URL? {
@@ -800,6 +881,12 @@ class MainWindow: Window {
             for item in module.navigationViewFooterMenuItemsRequired(in: context) {
                 appendNavigationItem(item, true)
             }
+        }
+
+        if let url = initialNavigationURL {
+            initialNavigationURL = nil
+            _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
+            return
         }
 
         if let page = viewModel.currentPage {

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -44,6 +44,14 @@ class MainWindow: Window {
     private var openInNewTabRequested: Bool = false
     private var initialNavigationURL: URL? = nil
     private var tabDragHintBorder: Border? = nil
+    private var draggingTabForDrop: MainWindowTab? = nil
+    private var dragDroppedOutside = false
+
+    private struct DragState {
+        let sourceWindowID: ObjectIdentifier
+        let tabURL: URL
+    }
+    private static var activeDrag: DragState? = nil
 
     /// UI 主要组件
     private static func makeNavButton(glyph: String, action: @escaping () -> Void) -> Button {
@@ -186,6 +194,7 @@ class MainWindow: Window {
         tabs.margin = Thickness(left: 0, top: -1, right: 0, bottom: 0)
         tabs.canDragTabs = true
         tabs.canReorderTabs = true
+        tabs.allowDrop = true
         return tabs
     } ()
     private lazy var tabContentHost = Grid()
@@ -366,27 +375,57 @@ class MainWindow: Window {
             self?.openNewTabFromTabStrip()
         }
 
-        tabView.tabDroppedOutside.addHandler { [weak self] _, args in
-            print("[TabDrag] tabDroppedOutside fired, args=\(String(describing: args)), tab=\(String(describing: args?.tab))")
-            guard let self, let args, let item = args.tab else {
-                print("[TabDrag] guard failed: self=\(self != nil), args=\(args != nil)")
-                return
+        // Source: record which tab is being dragged and expose it via static state for cross-window drop
+        tabView.tabDragStarting.addHandler { [weak self] _, args in
+            guard let self, let args, let item = args.tab else { return }
+            guard let tab = self.tab(for: item) else { return }
+            guard let url = tab.currentPage?.url else { return }
+            self.draggingTabForDrop = tab
+            MainWindow.activeDrag = DragState(sourceWindowID: ObjectIdentifier(self), tabURL: url)
+        }
+
+        // Source: flag that the tab was physically dropped outside (vs drag cancelled by Escape)
+        tabView.tabDroppedOutside.addHandler { [weak self] _, _ in
+            self?.dragDroppedOutside = true
+        }
+
+        // Source: decide outcome once drag completes
+        tabView.tabDragCompleted.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            let wasDroppedOutside = self.dragDroppedOutside
+            defer {
+                self.dragDroppedOutside = false
+                self.draggingTabForDrop = nil
+                MainWindow.activeDrag = nil
             }
-            guard let tab = self.tab(for: item) else {
-                print("[TabDrag] tab(for:) returned nil for item.name=\(item.name), tabIDByName=\(self.tabIDByName.keys.joined(separator: ","))")
-                return
+            guard let tab = self.draggingTabForDrop else { return }
+            guard self.viewModel.tabs.count > 1 else { return }
+            guard self.viewModel.tabs.contains(where: { $0 === tab }) else { return }
+
+            if args.dropResult == .none {
+                // No valid drop target accepted the drag; tear-off only when physically dropped (not Escape)
+                guard wasDroppedOutside else { return }
+                let url = tab.currentPage?.url
+                self.viewModel.close(tab: tab)
+                self.renderSelectedTab()
+                if let url { MainWindow.openDetachedWindow(navigatingTo: url) }
+            } else {
+                // Another window's TabView accepted the drop; close the tab from this window
+                self.viewModel.close(tab: tab)
+                self.renderSelectedTab()
             }
-            guard self.viewModel.tabs.count > 1 else {
-                print("[TabDrag] only 1 tab, skipping detach")
-                return
-            }
-            let url = tab.currentPage?.url
-            print("[TabDrag] detaching tab, navigating new window to \(url?.absoluteString ?? "nil")")
-            self.viewModel.close(tab: tab)
-            self.renderSelectedTab()
-            if let url {
-                MainWindow.openDetachedWindow(navigatingTo: url)
-            }
+        }
+
+        // Destination: accept tab drops from other windows' TabViews
+        tabView.dragOver.addHandler { [weak self] _, args in
+            guard let self, let args else { return }
+            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
+            args.acceptedOperation = .move
+        }
+        tabView.drop.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
+            _ = self.navigate(to: drag.tabURL, transitionInfoOverride: SuppressNavigationTransitionInfo(), inNewTab: true)
         }
 
         setupTabDragHint()
@@ -494,6 +533,9 @@ class MainWindow: Window {
         guard ids != tabStripIDs else {
             return
         }
+
+        isSyncingTabSelection = true
+        defer { isSyncingTabSelection = false }
 
         while items.size > viewModel.tabs.count {
             items.removeAt(items.size - 1)
@@ -675,7 +717,7 @@ class MainWindow: Window {
 
     private func setupTabDragHint() {
         let hintText = TextBlock()
-        hintText.text = tr("拖动标签到窗口外，释放可分离为独立窗口")
+        hintText.text = tr("拖到其他窗口可合并，拖到窗口外释放可分离为新窗口")
         hintText.fontSize = 12
         hintText.textWrapping = .wrap
         hintText.maxWidth = 460

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -35,6 +35,8 @@ class MainWindow: Window {
     private var dragStartPaneLength: Double = 0
     private let splitterWidth: Double = 6
 
+    private var openInNewTabRequested: Bool = false
+
     /// UI 主要组件
     private static func makeNavButton(glyph: String, action: @escaping () -> Void) -> Button {
         let icon = FontIcon()
@@ -365,6 +367,24 @@ class MainWindow: Window {
         navigationView.selectItem(with: url)
     }
 
+    private func captureOpenInNewTabRequested(_ args: PointerRoutedEventArgs?) {
+        guard let args = args else { return }
+        let rawValue = Int(args.keyModifiers.rawValue)
+        openInNewTabRequested = (rawValue & 0x1) != 0
+        print("ctrl was \((openInNewTabRequested ?? false) ? "" : "not") pressed when navigationView was clicked")
+    }
+
+    private func appendNavigationItem(_ item: NavigationViewItemBase, _ isFooter: Bool) {
+        item.pointerPressed.addHandler { [weak self] _, args in
+            self?.captureOpenInNewTabRequested(args)
+        }
+        if isFooter {
+            navigationView.footerMenuItems.append(item)
+        } else {
+            navigationView.menuItems.append(item)
+        }
+    }
+
     private func applyAppearance() {
         // For min/max/close buttons. 目前不支持材质效果，但比逐个设置按钮颜色简单，并且容易由框架修正。
         self.appWindow.titleBar.preferredTheme = App.context.theme.titleBarTheme
@@ -382,10 +402,10 @@ class MainWindow: Window {
                 titleBarRightHeader.children.append(item)
             }
             for item in module.navigationViewMenuItemsRequired(in: context) {
-                navigationView.menuItems.append(item)
+                appendNavigationItem(item, false)
             }
             for item in module.navigationViewFooterMenuItemsRequired(in: context) {
-                navigationView.footerMenuItems.append(item)
+                appendNavigationItem(item, true)
             }
         }
 

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -840,12 +840,13 @@ class MainWindow: Window {
         // Row 0: header — margin matches WinUI default NavigationViewHeaderMargin (56,44,0,0)
         let headerBorder = Border()
         headerBorder.margin = Thickness(left: 56, top: 44, right: 0, bottom: 0)
-        headerBorder.child = headerView
+        MainWindow.safelyAssignChild(headerView, toBorder: headerBorder)
         parts.headerBorder = headerBorder
 
         // Row 1: content
         let contentBorder = Border()
-        contentBorder.child = page.content
+        let pageContent = page.content
+        MainWindow.safelyAssignChild(pageContent, toBorder: contentBorder)
         parts.contentBorder = contentBorder
 
         try? Grid.setRow(headerBorder, 0)
@@ -853,6 +854,28 @@ class MainWindow: Window {
         grid.children.append(headerBorder)
         grid.children.append(contentBorder)
         return grid
+    }
+
+    /// 把 `child` 赋值给 `border.child` 之前先显式从原 parent 断开，
+    /// 防御 Page 把 UIElement 作为存储属性返回（如 Ruslan FolderView）导致的
+    /// "Element is already the child of another element" WinRT 异常 ——
+    /// 这种异常发生在 COM callback 路径里，会从 `try!` 抛出但传不到 Swift 主线程，
+    /// 进程不会真正终止，但相关 UI 操作会失败、日志会污染。
+    private static func safelyAssignChild(_ child: UIElement, toBorder border: Border) {
+        if let parent = try? VisualTreeHelper.getParent(child) {
+            if let parentBorder = parent as? Border {
+                parentBorder.child = nil
+            } else if let parentPanel = parent as? Panel {
+                var idx: UInt32 = 0
+                if parentPanel.children.indexOf(child, &idx) {
+                    parentPanel.children.removeAt(idx)
+                }
+            } else if let parentContent = parent as? ContentControl {
+                parentContent.content = nil
+            }
+            // 其他 parent 类型暂不处理；如有需要后续可扩展
+        }
+        border.child = child
     }
 
     private func syncNavigationSelection(for url: URL) {

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -857,7 +857,7 @@ class MainWindow: Window {
     }
 
     /// 把 `child` 赋值给 `border.child` 之前先显式从原 parent 断开，
-    /// 防御 Page 把 UIElement 作为存储属性返回（如 Ruslan FolderView）导致的
+    /// 防御 Page 把 UIElement 作为存储属性返回导致的 
     /// "Element is already the child of another element" WinRT 异常 ——
     /// 这种异常发生在 COM callback 路径里，会从 `try!` 抛出但传不到 Swift 主线程，
     /// 进程不会真正终止，但相关 UI 操作会失败、日志会污染。

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -53,6 +53,11 @@ class MainWindow: Window {
     }
     private static var activeDrag: DragState? = nil
 
+    // 持有 Observation Task 句柄，窗口关闭时 cancel，避免死窗口的 task 继续访问失效的 self.appWindow / self.viewModel
+    private var envObservationTask: Task<Void, Never>?
+    private var routeObservationTask: Task<Void, Never>?
+    private var isApplyingAppearance = false
+
     /// UI 主要组件
     private static func makeNavButton(glyph: String, action: @escaping () -> Void) -> Button {
         let icon = FontIcon()
@@ -319,6 +324,12 @@ class MainWindow: Window {
         self.closed.addHandler { [weak self] _, _ in
             guard let self else { return }
 
+            // 先 cancel observation tasks，避免死窗口的 task 继续访问 self.appWindow / self.viewModel
+            self.envObservationTask?.cancel()
+            self.routeObservationTask?.cancel()
+            self.envObservationTask = nil
+            self.routeObservationTask = nil
+
             // TODO: appWindow.changed事件不工作，此处窗口最大化时记录有缺陷。其实也可以不保存，恢复窗口在中间即可。
             self.trackWindowPosition()
             self.viewModel.windowLayout.navigationViewPaneOpen = self.navigationView.isPaneOpen
@@ -450,11 +461,11 @@ class MainWindow: Window {
         self.content = root
     }
 
-    private func startObserving() { 
+    private func startObserving() {
         let env = Observations {
             (App.context.theme, App.context.language)
         }
-        Task { [weak self] in
+        envObservationTask = Task { [weak self] in
             for await _ in env {
                 await MainActor.run { [weak self] in
                     self?.applyAppearance()
@@ -462,13 +473,16 @@ class MainWindow: Window {
             }
         }
 
+        // viewModel 在 closed handler 里会被设为 nil（包括最大化最后一个 tab 的场景），
+        // 此处必须用 ?. 避免 IUO 强解包崩溃；renderSelectedTab 也会再做一次 nil 检查
         let route = Observations {
-            self.viewModel.navigationRevision
+            self.viewModel?.navigationRevision ?? 0
         }
-        Task { [weak self] in
+        routeObservationTask = Task { [weak self] in
             for await _ in route {
                 await MainActor.run { [weak self] in
-                    self?.renderSelectedTab()
+                    guard let self, self.viewModel != nil else { return }
+                    self.renderSelectedTab()
                 }
             }
         }
@@ -914,6 +928,13 @@ class MainWindow: Window {
     }
 
     private func applyAppearance() {
+        // 死窗口防御：closed handler 把 viewModel 置为 nil，此时 appWindow 也已失效（IUO → nil）
+        guard viewModel != nil, appWindow != nil else { return }
+        // 防止并发/重入（多窗口下 env Observation 接连触发可能引发 menuItems 的双 parent 错误）
+        guard !isApplyingAppearance else { return }
+        isApplyingAppearance = true
+        defer { isApplyingAppearance = false }
+
         // For min/max/close buttons. 目前不支持材质效果，但比逐个设置按钮颜色简单，并且容易由框架修正。
         self.appWindow.titleBar.preferredTheme = App.context.theme.titleBarTheme
 

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -4,61 +4,42 @@ import WindowsFoundation
 import UWP
 import WinAppSDK
 import WinUI
-import WinSDK
-import RsHelper
-
-fileprivate func tr(_ keyAndValue: String) -> String {
-    return App.context.tr(keyAndValue)
-}
-
-fileprivate extension WindowPosition {
-    var windowRect: RectInt32 {
-        return RectInt32(
-            x: Int32(windowX),
-            y: Int32(windowY),
-            width: Int32(windowWidth),
-            height: Int32(windowHeight)
-        )
-    }
-}
-
-/// 主窗口类，管理整个应用的导航和 UI 布局
-private final class PageViewParts {
-    var contentBorder: Border?
-    var headerBorder: Border?
-}
 
 class MainWindow: Window {
     // MARK: - 属性
-    private var viewModel: MainWindowViewModel! = MainWindowViewModel()
-    private var isSyncingSelection = false
-    private var isSyncingTabSelection = false
+    var viewModel: MainWindowViewModel! = MainWindowViewModel()
+    var isSyncingSelection = false
+    var isSyncingTabSelection = false
 
     // Splitter state
-    private var splitterBorder: Border!
-    private var isDraggingSplitter = false
-    private var dragStartX: Double = 0
-    private var dragStartPaneLength: Double = 0
-    private let splitterWidth: Double = 6
+    var splitterBorder: Border!
+    var isDraggingSplitter = false
+    var dragStartX: Double = 0
+    var dragStartPaneLength: Double = 0
+    let splitterWidth: Double = 6
 
-    private var openInNewTabRequested: Bool = false
-    private var initialNavigationURL: URL? = nil
-    private var tabDragHintBorder: Border? = nil
-    private var draggingTabForDrop: MainWindowTab? = nil
-    private var dragDroppedOutside = false
+    var openInNewTabRequested: Bool = false
+    var initialNavigationURL: URL? = nil
+    var tabDragHintBorder: Border? = nil
+    var draggingTabForDrop: MainWindowTab? = nil
+    var dragDroppedOutside = false
 
-    private struct DragState {
+    struct DragState {
         let sourceWindowID: ObjectIdentifier
         let tabURL: URL
     }
-    private static var activeDrag: DragState? = nil
+    static var activeDrag: DragState? = nil
 
     // 持有 Observation Task 句柄，窗口关闭时 cancel，避免死窗口的 task 继续访问失效的 self.appWindow / self.viewModel
-    private var envObservationTask: Task<Void, Never>?
-    private var routeObservationTask: Task<Void, Never>?
-    private var isApplyingAppearance = false
+    var envObservationTask: Task<Void, Never>?
+    var routeObservationTask: Task<Void, Never>?
+    var isApplyingAppearance = false
 
     /// UI 主要组件
+    static func tr(_ keyAndValue: String) -> String {
+        return App.context.tr(keyAndValue)
+    }
+
     private static func makeNavButton(glyph: String, action: @escaping () -> Void) -> Button {
         let icon = FontIcon()
         icon.glyph = glyph
@@ -91,17 +72,17 @@ class MainWindow: Window {
         return btn
     }
 
-    private lazy var backButton: Button = MainWindow.makeNavButton(glyph: "\u{E72B}") { [weak self] in
+    lazy var backButton: Button = MainWindow.makeNavButton(glyph: "\u{E72B}") { [weak self] in
         guard let self else { return }
         self.viewModel.goBack(MainWindow.makeSlideTransition(effect: .fromLeft))
         self.renderSelectedTab()
     }
-    private lazy var forwardButton: Button = MainWindow.makeNavButton(glyph: "\u{E72A}") { [weak self] in
+    lazy var forwardButton: Button = MainWindow.makeNavButton(glyph: "\u{E72A}") { [weak self] in
         guard let self else { return }
         self.viewModel.goForward(MainWindow.makeSlideTransition(effect: .fromRight))
         self.renderSelectedTab()
     }
-    private lazy var closeOtherTabsButton: Button = {
+    lazy var closeOtherTabsButton: Button = {
         let icon = FontIcon()
         icon.glyph = "\u{E8BB}"
         icon.fontSize = 12
@@ -132,11 +113,11 @@ class MainWindow: Window {
             self?.closeOtherTabs()
         }
         let toolTip = ToolTip()
-        toolTip.content = tr("关闭其他标签")
+        toolTip.content = MainWindow.tr("关闭其他标签")
         try? ToolTipService.setToolTip(btn, toolTip)
         return btn
     }()
-    private lazy var searchBox: AutoSuggestBox? = {
+    lazy var searchBox: AutoSuggestBox? = {
         // let box = AutoSuggestBox()
         // box.width = 360
         // box.height = 32
@@ -145,12 +126,12 @@ class MainWindow: Window {
         // return box
         return nil
     } ()
-    private lazy var titleBarRightHeader = {
+    lazy var titleBarRightHeader = {
         let panel = StackPanel()
         panel.orientation = .horizontal
         return panel
     } ()
-    private lazy var titleBar = {
+    lazy var titleBar = {
         let bar = TitleBar()
         bar.height = 48
         bar.isBackButtonVisible = false
@@ -189,7 +170,7 @@ class MainWindow: Window {
 
         return bar
     } ()
-    private lazy var tabView: TabView = {
+    lazy var tabView: TabView = {
         let tabs = TabView()
         tabs.isAddTabButtonVisible = true
         tabs.tabWidthMode = .equal
@@ -202,8 +183,8 @@ class MainWindow: Window {
         tabs.allowDrop = true
         return tabs
     } ()
-    private lazy var tabContentHost = Grid()
-    private lazy var navigationContentRoot: Grid = {
+    lazy var tabContentHost = Grid()
+    lazy var navigationContentRoot: Grid = {
         let grid = Grid()
 
         let tabRow = RowDefinition()
@@ -221,17 +202,17 @@ class MainWindow: Window {
 
         return grid
     } ()
-    private var tabItemsByID: [ObjectIdentifier: TabViewItem] = [:]
+    var tabItemsByID: [ObjectIdentifier: TabViewItem] = [:]
     // Stable string name keyed to tab identity — avoids WinRT projection object identity instability
-    private var tabIDByName: [String: ObjectIdentifier] = [:]
-    private var tabFramesByID: [ObjectIdentifier: PageTransitionHost] = [:]
-    private var tabPageViewPartsByID: [ObjectIdentifier: PageViewParts] = [:]
-    private var tabStripIDs: [ObjectIdentifier] = []
-    private var tabTitlesByID: [ObjectIdentifier: String] = [:]
-    private var tabClosableByID: [ObjectIdentifier: Bool] = [:]
-    private var visibleTabFrameID: ObjectIdentifier?
-    private var isFirstNavigation = true
-    private lazy var navigationView = {
+    var tabIDByName: [String: ObjectIdentifier] = [:]
+    var tabFramesByID: [ObjectIdentifier: PageTransitionHost] = [:]
+    var tabPageViewPartsByID: [ObjectIdentifier: PageViewParts] = [:]
+    var tabStripIDs: [ObjectIdentifier] = []
+    var tabTitlesByID: [ObjectIdentifier: String] = [:]
+    var tabClosableByID: [ObjectIdentifier: Bool] = [:]
+    var visibleTabFrameID: ObjectIdentifier?
+    var isFirstNavigation = true
+    lazy var navigationView = {
         let nav = NavigationView()
         nav.paneDisplayMode = .left
         nav.isSettingsVisible = true
@@ -264,906 +245,5 @@ class MainWindow: Window {
         let transition = SlideNavigationTransitionInfo()
         transition.effect = effect
         return transition
-    }
-
-    func navigate(
-        to page: Page,
-        mode: NavigationOpenMode = .inplace,
-        transitionInfoOverride: NavigationTransitionInfo? = nil
-    ) {
-        let effective = resolveOpenMode(mode)
-        performNavigate(to: page, mode: effective, transitionInfoOverride: transitionInfoOverride)
-    }
-
-    @discardableResult
-    func navigate(
-        to url: URL,
-        mode: NavigationOpenMode = .inplace,
-        transitionInfoOverride: NavigationTransitionInfo? = nil
-    ) -> Bool {
-        let effective = resolveOpenMode(mode)
-        return performNavigate(to: url, mode: effective, transitionInfoOverride: transitionInfoOverride)
-    }
-
-    /// NavigationViewItem 上 Ctrl+click 设置的 `openInNewTabRequested` 标记会把
-    /// `.inplace` 升级为 `.newTab`；调用者显式指定的非 inplace 模式不被覆盖。
-    private func resolveOpenMode(_ requested: NavigationOpenMode) -> NavigationOpenMode {
-        let flag = openInNewTabRequested
-        openInNewTabRequested = false
-        if requested == .inplace && flag {
-            return .newTab
-        }
-        return requested
-    }
-
-    private func performNavigate(
-        to page: Page,
-        mode: NavigationOpenMode,
-        transitionInfoOverride: NavigationTransitionInfo?
-    ) {
-        if mode == .newWindow {
-            MainWindow.openDetachedWindow(navigatingTo: page.url)
-            return
-        }
-        viewModel.navigate(
-            to: page,
-            transitionInfoOverride: transitionInfoOverride,
-            inNewTab: mode != .inplace,
-            switchToTab: mode != .newTabBackground
-        )
-        renderSelectedTab()
-    }
-
-    @discardableResult
-    private func performNavigate(
-        to url: URL,
-        mode: NavigationOpenMode,
-        transitionInfoOverride: NavigationTransitionInfo?
-    ) -> Bool {
-        if mode == .newWindow {
-            MainWindow.openDetachedWindow(navigatingTo: url)
-            return true
-        }
-        // 仅在 inplace 模式下短路；其他模式（newTab / newTabBackground）允许重复打开同 URL
-        if mode == .inplace, viewModel.currentPage?.url == url {
-            return true
-        }
-
-        if url == SettingsPage.url {
-            performNavigate(to: SettingsPage(), mode: mode, transitionInfoOverride: transitionInfoOverride)
-            return true
-        } else {
-            let context = WindowContext(owner: self)
-            for module in App.context.modules {
-                if let page = module.navigationRequested(for: url, in: context) {
-                    performNavigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
-                    return true
-                }
-            }
-        }
-        return false
-    }
- 
-    /// 配置窗口基本属性
-    private func setupWindow() {
-        self.extendsContentIntoTitleBar = true
-        self.appWindow.titleBar.preferredHeightOption = .tall
-                
-        // 设置 Mica 背景
-        let micaBackdrop = MicaBackdrop()
-        micaBackdrop.kind = .base
-        self.systemBackdrop = micaBackdrop
-
-        self.sizeChanged.addHandler { [weak self] _, _ in
-            self?.trackWindowSize()
-        }
-        self.closed.addHandler { [weak self] _, _ in
-            guard let self else { return }
-
-            // 先 cancel observation tasks，避免死窗口的 task 继续访问 self.appWindow / self.viewModel
-            self.envObservationTask?.cancel()
-            self.routeObservationTask?.cancel()
-            self.envObservationTask = nil
-            self.routeObservationTask = nil
-
-            // TODO: appWindow.changed事件不工作，此处窗口最大化时记录有缺陷。其实也可以不保存，恢复窗口在中间即可。
-            self.trackWindowPosition()
-            self.viewModel.windowLayout.navigationViewPaneOpen = self.navigationView.isPaneOpen
-            self.viewModel.windowLayout.navigationViewOpenPaneLength = self.navigationView.openPaneLength
-            self.viewModel = nil
-        }
-        restoreWindowRect()
-    }
-
-    /// 初始化主要的 UI 布局
-    private func setupContent() {
-        let root = Grid()
-
-        // 设置行定义
-        let titleRowDef = RowDefinition()
-        titleRowDef.height = GridLength(value: 1, gridUnitType: .auto)
-        root.rowDefinitions.append(titleRowDef)
-        
-        let contentRowDef = RowDefinition()
-        contentRowDef.height = GridLength(value: 1, gridUnitType: .star)
-        root.rowDefinitions.append(contentRowDef)
-        
-        root.children.append(titleBar)
-        try? Grid.setRow(titleBar, 0)
-        try? setTitleBar(titleBar)
-        
-        navigationView.selectionChanged.addHandler { [weak self] _, args in
-            guard let self, let args, !self.isSyncingSelection else { return }
-
-            if args.isSettingsSelected {
-                navigate(to: SettingsPage(), transitionInfoOverride: SuppressNavigationTransitionInfo())
-            } else if
-                let item = args.selectedItem as? NavigationViewItem,
-                let tag = item.tag,
-                let str = tag as? HString,
-                let url = URL(string: String(hString: str)) {
-                _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
-            }
-        }
-
-        tabView.selectionChanged.addHandler { [weak self] sender, args in
-            guard let self, !self.isSyncingTabSelection else { return }
-            guard let item = self.selectedTabViewItem(sender: sender, args: args) else { return }
-            guard let tab = self.tab(for: item) else { return }
-            self.switchToTab(tab)
-        }
-
-        tabView.tabCloseRequested.addHandler { [weak self] _, args in
-            guard let self, let args, let item = args.tab else { return }
-            self.closeTab(for: item)
-        }
-
-        tabView.addTabButtonClick.addHandler { [weak self] _, _ in
-            self?.openNewTabFromTabStrip()
-        }
-
-        // Source: record which tab is being dragged and expose it via static state for cross-window drop
-        tabView.tabDragStarting.addHandler { [weak self] _, args in
-            guard let self, let args, let item = args.tab else { return }
-            guard let tab = self.tab(for: item) else { return }
-            guard let url = tab.currentPage?.url else { return }
-            self.draggingTabForDrop = tab
-            MainWindow.activeDrag = DragState(sourceWindowID: ObjectIdentifier(self), tabURL: url)
-        }
-
-        // Source: flag that the tab was physically dropped outside (vs drag cancelled by Escape)
-        tabView.tabDroppedOutside.addHandler { [weak self] _, _ in
-            self?.dragDroppedOutside = true
-        }
-
-        // Source: decide outcome once drag completes
-        tabView.tabDragCompleted.addHandler { [weak self] _, args in
-            guard let self, let args else { return }
-            let wasDroppedOutside = self.dragDroppedOutside
-            defer {
-                self.dragDroppedOutside = false
-                self.draggingTabForDrop = nil
-                MainWindow.activeDrag = nil
-            }
-            guard let tab = self.draggingTabForDrop else { return }
-            guard self.viewModel.tabs.count > 1 else { return }
-            guard self.viewModel.tabs.contains(where: { $0 === tab }) else { return }
-
-            if args.dropResult == .none {
-                // No valid drop target accepted the drag; tear-off only when physically dropped (not Escape)
-                guard wasDroppedOutside else { return }
-                let url = tab.currentPage?.url
-                self.viewModel.close(tab: tab)
-                self.renderSelectedTab()
-                if let url { MainWindow.openDetachedWindow(navigatingTo: url) }
-            } else {
-                // Another window's TabView accepted the drop; close the tab from this window
-                self.viewModel.close(tab: tab)
-                self.renderSelectedTab()
-            }
-        }
-
-        // Destination: accept tab drops from other windows' TabViews
-        tabView.dragOver.addHandler { [weak self] _, args in
-            guard let self, let args else { return }
-            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
-            args.acceptedOperation = .move
-        }
-        tabView.drop.addHandler { [weak self] _, _ in
-            guard let self else { return }
-            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
-            _ = self.navigate(to: drag.tabURL, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
-        }
-
-        setupTabDragHint()
-
-        navigationView.paneClosed.addHandler { [weak self] _, _ in
-            self?.splitterBorder.visibility = .collapsed
-        }
-        navigationView.paneOpened.addHandler { [weak self] _, _ in
-            self?.splitterBorder.visibility = .visible
-        }
-
-        // Wrap NavigationView with splitter overlay
-        let navWrapper = Grid()
-        navWrapper.children.append(navigationView)
-        splitterBorder = makeSplitterBorder()
-        navWrapper.children.append(splitterBorder)
-        try? Canvas.setZIndex(splitterBorder, 10)
-
-        root.children.append(navWrapper)
-        try? Grid.setRow(navWrapper, 1)
-
-        self.content = root
-    }
-
-    private func startObserving() {
-        let env = Observations {
-            (App.context.theme, App.context.language)
-        }
-        envObservationTask = Task { [weak self] in
-            for await _ in env {
-                await MainActor.run { [weak self] in
-                    self?.applyAppearance()
-                }
-            }
-        }
-
-        // viewModel 在 closed handler 里会被设为 nil（包括最大化最后一个 tab 的场景），
-        // 此处必须用 ?. 避免 IUO 强解包崩溃；renderSelectedTab 也会再做一次 nil 检查
-        let route = Observations {
-            self.viewModel?.navigationRevision ?? 0
-        }
-        routeObservationTask = Task { [weak self] in
-            for await _ in route {
-                await MainActor.run { [weak self] in
-                    guard let self, self.viewModel != nil else { return }
-                    self.renderSelectedTab()
-                }
-            }
-        }
-    }
-
-    private func renderSelectedTab() {
-        syncTabItems()
-        updateTabStripVisibility()
-
-        guard let tab = viewModel.selectedTab, let page = tab.currentPage else {
-            navigationView.header = nil
-            hideAllTabFrames()
-            navigationView.selectedItem = nil
-            backButton.isEnabled = false
-            forwardButton.isEnabled = false
-            return
-        }
-
-        navigationView.header = nil
-        updateTabItemState(for: tab)
-        let frame = showFrame(for: tab)
-
-        if tab.needsRender {
-            let effectiveTransitionInfo: NavigationTransitionInfo?
-            if isFirstNavigation {
-                effectiveTransitionInfo = SuppressNavigationTransitionInfo()
-                isFirstNavigation = false
-            } else {
-                effectiveTransitionInfo = tab.navigationTransitionInfo
-            }
-            frame.transition(
-                to: makePageView(page, for: tab),
-                transitionInfo: effectiveTransitionInfo
-            )
-            tab.needsRender = false
-        }
-
-        let tabItem = tabViewItem(for: tab)
-        if !tabViewItem(tabView.selectedItem as? TabViewItem, represents: ObjectIdentifier(tab)) {
-            isSyncingTabSelection = true
-            tabView.selectedItem = tabItem
-            isSyncingTabSelection = false
-        }
-
-        syncNavigationSelection(for: page.url)
-        backButton.isEnabled = !tab.backwardPages.isEmpty
-        forwardButton.isEnabled = !tab.forwardPages.isEmpty
-    }
-
-    private func syncTabItems() {
-        guard let items = tabView.tabItems else { return }
-
-        let ids = viewModel.tabs.map { ObjectIdentifier($0) }
-        let activeIDs = Set(ids)
-        tabItemsByID = tabItemsByID.filter { activeIDs.contains($0.key) }
-        tabIDByName = tabIDByName.filter { activeIDs.contains($0.value) }
-        tabTitlesByID = tabTitlesByID.filter { activeIDs.contains($0.key) }
-        tabClosableByID = tabClosableByID.filter { activeIDs.contains($0.key) }
-        tabPageViewPartsByID = tabPageViewPartsByID.filter { activeIDs.contains($0.key) }
-        removeClosedTabFrames(activeIDs: activeIDs)
-
-        guard ids != tabStripIDs else {
-            return
-        }
-
-        isSyncingTabSelection = true
-        defer { isSyncingTabSelection = false }
-
-        // Step 1: 按身份精确移除 items 中所有不再属于 viewModel.tabs 的 TabViewItem。
-        //   旧版只 `items.removeAt(items.size - 1)` 截尾，关闭非末尾 tab 时残留错位 item，
-        //   后续 insertAt 会试图把同一 UIElement 插到已存在位置 → "two parents" WinRT 异常。
-        var i: UInt32 = 0
-        while i < items.size {
-            if let item = items.getAt(i) as? TabViewItem,
-               let id = tabIDByName[item.name],
-               activeIDs.contains(id) {
-                i += 1
-            } else {
-                items.removeAt(i)
-            }
-        }
-
-        // Step 2: 重排到目标顺序。如果目标 tabItem 已在 items 中（错位），先从原位置移除再插入。
-        for (index, tab) in viewModel.tabs.enumerated() {
-            let id = ObjectIdentifier(tab)
-            let tabItem = tabViewItem(for: tab)
-            if UInt32(index) < items.size,
-               let item = items.getAt(UInt32(index)) as? TabViewItem,
-               tabViewItem(item, represents: id) {
-                continue
-            }
-
-            // 找一下 tabItem 是否已在 items 别处
-            var existingIndex: UInt32? = nil
-            var j: UInt32 = 0
-            while j < items.size {
-                if let item = items.getAt(j) as? TabViewItem,
-                   tabViewItem(item, represents: id) {
-                    existingIndex = j
-                    break
-                }
-                j += 1
-            }
-            if let existingIndex {
-                items.removeAt(existingIndex)
-            }
-            items.insertAt(UInt32(index), tabItem)
-        }
-        tabStripIDs = ids
-        updateAllTabItemCloseStates()
-    }
-
-    private func tabViewItem(_ item: TabViewItem?, represents id: ObjectIdentifier) -> Bool {
-        guard let item else { return false }
-        if tabIDByName[item.name] == id {
-            return true
-        }
-        return tabItemsByID[id] === item
-    }
-
-    private func updateTabStripVisibility() {
-        tabView.visibility = viewModel.tabs.count <= 1 ? .collapsed : .visible
-    }
-
-    private func openNewTabFromTabStrip() {
-        if let url = firstNavigationItemURL() {
-            _ = navigate(to: url, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
-        } else {
-            navigate(to: SettingsPage(), mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
-        }
-    }
-
-    private func tabViewItem(for tab: MainWindowTab) -> TabViewItem {
-        let id = ObjectIdentifier(tab)
-        if let item = tabItemsByID[id] {
-            return item
-        }
-
-        let item = TabViewItem()
-        let name = id.debugDescription
-        item.name = name
-        tabIDByName[name] = id
-        item.tapped.addHandler { [weak self, weak item] _, _ in
-            guard let self, let item, let tab = self.tab(for: item) else { return }
-            self.switchToTab(tab)
-        }
-        item.closeRequested.addHandler { [weak self, weak item] _, _ in
-            guard let self, let item else { return }
-            self.closeTab(for: item)
-        }
-        tabItemsByID[id] = item
-        updateTabItemState(for: tab)
-        return item
-    }
-
-    private func updateTabItemState(for tab: MainWindowTab) {
-        let id = ObjectIdentifier(tab)
-        guard let item = tabItemsByID[id] else { return }
-
-        let newTitle = title(for: tab.currentPage)
-        if tabTitlesByID[id] != newTitle {
-            item.header = newTitle
-            tabTitlesByID[id] = newTitle
-        }
-
-        let canClose = viewModel.tabs.count > 1
-        if tabClosableByID[id] != canClose {
-            item.isClosable = canClose
-            tabClosableByID[id] = canClose
-        }
-    }
-
-    private func updateAllTabItemCloseStates() {
-        for tab in viewModel.tabs {
-            updateTabItemState(for: tab)
-        }
-    }
-
-    private func frame(for tab: MainWindowTab) -> PageTransitionHost {
-        let id = ObjectIdentifier(tab)
-        if let frame = tabFramesByID[id] {
-            return frame
-        }
-
-        let frame = PageTransitionHost()
-        frame.visibility = .collapsed
-        tabFramesByID[id] = frame
-        tabContentHost.children.append(frame)
-        return frame
-    }
-
-    private func showFrame(for tab: MainWindowTab) -> PageTransitionHost {
-        let id = ObjectIdentifier(tab)
-        let selectedFrame = frame(for: tab)
-        guard visibleTabFrameID != id else {
-            return selectedFrame
-        }
-
-        for (frameID, frame) in tabFramesByID {
-            frame.visibility = frameID == id ? .visible : .collapsed
-        }
-        visibleTabFrameID = id
-        return selectedFrame
-    }
-
-    private func hideAllTabFrames() {
-        for frame in tabFramesByID.values {
-            frame.visibility = .collapsed
-        }
-        visibleTabFrameID = nil
-    }
-
-    private func removeClosedTabFrames(activeIDs: Set<ObjectIdentifier>) {
-        let closedIDs = tabFramesByID.keys.filter { !activeIDs.contains($0) }
-        for id in closedIDs {
-            guard let frame = tabFramesByID.removeValue(forKey: id) else { continue }
-            removeTabFrame(frame)
-            if visibleTabFrameID == id {
-                visibleTabFrameID = nil
-            }
-        }
-    }
-
-    private func removeTabFrame(_ frame: PageTransitionHost) {
-        var idx: UInt32 = 0
-        if tabContentHost.children.indexOf(frame, &idx) {
-            tabContentHost.children.removeAt(idx)
-        }
-    }
-
-    private func tab(for item: TabViewItem) -> MainWindowTab? {
-        // Primary: stable name-based lookup (avoids WinRT projection identity instability)
-        if let id = tabIDByName[item.name], let tab = viewModel.tabs.first(where: { ObjectIdentifier($0) == id }) {
-            return tab
-        }
-        // Fallback: identity comparison
-        for tab in viewModel.tabs {
-            if tabItemsByID[ObjectIdentifier(tab)] === item {
-                return tab
-            }
-        }
-        return nil
-    }
-
-    private func selectedTabViewItem(sender: Any?, args: SelectionChangedEventArgs?) -> TabViewItem? {
-        if
-            let args,
-            let addedItems = args.addedItems,
-            addedItems.size > 0,
-            let item = addedItems.getAt(0) as? TabViewItem {
-            return item
-        }
-
-        if let tabView = sender as? TabView {
-            return tabView.selectedItem as? TabViewItem
-        }
-
-        return tabView.selectedItem as? TabViewItem
-    }
-
-    private func switchToTab(_ tab: MainWindowTab) {
-        guard viewModel.selectedTab !== tab else { return }
-        viewModel.select(tab: tab)
-        renderSelectedTab()
-    }
-
-    private func closeTab(for item: TabViewItem) {
-        guard let tab = tab(for: item) else { return }
-        viewModel.close(tab: tab)
-        renderSelectedTab()
-    }
-
-    private func closeOtherTabs() {
-        viewModel.closeOtherTabs()
-        renderSelectedTab()
-    }
-
-    private func setupTabDragHint() {
-        let hintText = TextBlock()
-        hintText.text = tr("拖到其他窗口可合并，拖到窗口外释放可分离为新窗口")
-        hintText.fontSize = 12
-        hintText.textWrapping = .wrap
-        hintText.maxWidth = 460
-        hintText.foreground = SolidColorBrush(UWP.Color(a: 255, r: 245, g: 249, b: 255))
-
-        let hintBorder = Border()
-        hintBorder.background = SolidColorBrush(UWP.Color(a: 230, r: 21, g: 94, b: 175))
-        hintBorder.borderBrush = SolidColorBrush(UWP.Color(a: 255, r: 166, g: 215, b: 255))
-        hintBorder.borderThickness = Thickness(left: 1, top: 1, right: 1, bottom: 1)
-        hintBorder.cornerRadius = CornerRadius(topLeft: 10, topRight: 10, bottomRight: 10, bottomLeft: 10)
-        hintBorder.padding = Thickness(left: 12, top: 8, right: 12, bottom: 8)
-        hintBorder.horizontalAlignment = .center
-        hintBorder.verticalAlignment = .top
-        hintBorder.margin = Thickness(left: 0, top: 12, right: 0, bottom: 0)
-        hintBorder.opacity = 0
-        hintBorder.visibility = .collapsed
-        hintBorder.isHitTestVisible = false
-        hintBorder.child = hintText
-        try? Canvas.setZIndex(hintBorder, 99)
-        tabContentHost.children.append(hintBorder)
-        tabDragHintBorder = hintBorder
-
-        tabView.tabDragStarting.addHandler { [weak hintBorder] _, _ in
-            hintBorder?.visibility = .visible
-            hintBorder?.opacity = 1
-        }
-        tabView.tabDragCompleted.addHandler { [weak hintBorder] _, _ in
-            hintBorder?.opacity = 0
-            hintBorder?.visibility = .collapsed
-        }
-    }
-
-    static func openDetachedWindow(navigatingTo url: URL) {
-        let window = MainWindow()
-        window.initialNavigationURL = url
-        try? window.activate()
-    }
-
-    private func firstNavigationItemURL() -> URL? {
-        return firstNavigationItemURL(in: navigationView.menuItems)
-            ?? firstNavigationItemURL(in: navigationView.footerMenuItems)
-    }
-
-    private func firstNavigationItemURL(in items: AnyIVector<Any?>?) -> URL? {
-        guard let items else { return nil }
-
-        for item in items {
-            guard let navItem = item as? NavigationViewItem else { continue }
-            if
-                let tag = navItem.tag,
-                let str = tag as? HString,
-                let url = URL(string: String(hString: str)) {
-                return url
-            }
-            if let url = firstNavigationItemURL(in: navItem.menuItems) {
-                return url
-            }
-        }
-
-        return nil
-    }
-
-    private func title(for page: Page?) -> String {
-        guard let page else { return tr("New Tab") }
-        if let text = page.header as? String, !text.isEmpty {
-            return text
-        }
-
-        let host = page.url.host ?? page.url.absoluteString
-        return host.isEmpty ? page.url.absoluteString : host
-    }
-
-    private func makePageView(_ page: Page, for tab: MainWindowTab) -> UIElement {
-        let tabID = ObjectIdentifier(tab)
-        let parts = tabPageViewPartsByID[tabID] ?? PageViewParts()
-        parts.contentBorder?.child = nil
-        parts.headerBorder?.child = nil
-        parts.contentBorder = nil
-        parts.headerBorder = nil
-        tabPageViewPartsByID[tabID] = parts
-
-        // String header → 同时渲染为页面顶部 28pt 大标题 + 通过 title(for:) 用作 Tab 标签
-        // UIElement header → 直接渲染到页面顶部
-        let headerView: UIElement
-        if let text = page.header as? String {
-            let tb = TextBlock()
-            tb.text = text
-            tb.fontSize = 28
-            tb.fontWeight = FontWeights.semiBold
-            tb.textWrapping = .wrap
-            headerView = tb
-        } else if let view = page.header as? UIElement {
-            headerView = view
-        } else {
-            return page.content
-        }
-
-        let grid = Grid()
-        let autoRow = RowDefinition()
-        autoRow.height = GridLength(value: 0, gridUnitType: .auto)
-        let starRow = RowDefinition()
-        starRow.height = GridLength(value: 1, gridUnitType: .star)
-        grid.rowDefinitions.append(autoRow)
-        grid.rowDefinitions.append(starRow)
-
-        // Row 0: header — margin matches WinUI default NavigationViewHeaderMargin (56,44,0,0)
-        let headerBorder = Border()
-        headerBorder.margin = Thickness(left: 56, top: 44, right: 0, bottom: 0)
-        MainWindow.safelyAssignChild(headerView, toBorder: headerBorder)
-        parts.headerBorder = headerBorder
-
-        // Row 1: content
-        let contentBorder = Border()
-        let pageContent = page.content
-        MainWindow.safelyAssignChild(pageContent, toBorder: contentBorder)
-        parts.contentBorder = contentBorder
-
-        try? Grid.setRow(headerBorder, 0)
-        try? Grid.setRow(contentBorder, 1)
-        grid.children.append(headerBorder)
-        grid.children.append(contentBorder)
-        return grid
-    }
-
-    /// 把 `child` 赋值给 `border.child` 之前先显式从原 parent 断开，
-    /// 防御 Page 把 UIElement 作为存储属性返回导致的 
-    /// "Element is already the child of another element" WinRT 异常 ——
-    /// 这种异常发生在 COM callback 路径里，会从 `try!` 抛出但传不到 Swift 主线程，
-    /// 进程不会真正终止，但相关 UI 操作会失败、日志会污染。
-    private static func safelyAssignChild(_ child: UIElement, toBorder border: Border) {
-        detachFromVisualParent(child)
-        border.child = child
-    }
-
-    /// 把 element 从其当前 visual parent 上断开。覆盖 Border / Panel / ContentControl /
-    /// ContentPresenter 这几种最常见的 parent 类型。其他类型（如 ItemsControl 直接挂载
-    /// arbitrary UIElement，理论上不应该出现）打日志方便排查。
-    private static func detachFromVisualParent(_ element: UIElement) {
-        guard let parent = try? VisualTreeHelper.getParent(element) else { return }
-        if let parentBorder = parent as? Border {
-            parentBorder.child = nil
-        } else if let parentPanel = parent as? Panel {
-            var idx: UInt32 = 0
-            if parentPanel.children.indexOf(element, &idx) {
-                parentPanel.children.removeAt(idx)
-            }
-        } else if let parentContent = parent as? ContentControl {
-            parentContent.content = nil
-        } else if let parentPresenter = parent as? ContentPresenter {
-            parentPresenter.content = nil
-        } else {
-            print("[RsUI] detachFromVisualParent: unsupported parent type \(type(of: parent)) for child \(type(of: element)) — 'Element is already the child of another element' may follow")
-        }
-    }
-
-    private func syncNavigationSelection(for url: URL) {
-        isSyncingSelection = true
-        defer { isSyncingSelection = false }
-        
-        navigationView.selectItem(with: url)
-    }
-
-    private func captureOpenInNewTabRequested(_ args: PointerRoutedEventArgs?) {
-        guard let args = args else { return }
-        let rawValue = Int(args.keyModifiers.rawValue)
-        openInNewTabRequested = (rawValue & 0x1) != 0
-        print("ctrl was \(openInNewTabRequested ? "" : "not") pressed when navigationView was clicked")
-    }
-
-    private func appendNavigationItem(_ item: NavigationViewItemBase, _ isFooter: Bool) {
-        item.pointerPressed.addHandler { [weak self, weak item] _, args in
-            guard let self else { return }
-            self.captureOpenInNewTabRequested(args)
-            guard self.openInNewTabRequested, let item else { return }
-            self.openSelectedNavigationItemInNewTabIfNeeded(item, args)
-        }
-        if isFooter {
-            navigationView.footerMenuItems.append(item)
-        } else {
-            navigationView.menuItems.append(item)
-        }
-    }
-
-    private func openSelectedNavigationItemInNewTabIfNeeded(_ item: NavigationViewItemBase, _ args: PointerRoutedEventArgs?) {
-        guard isNavigationItemSelected(item), let url = url(for: item) else { return }
-
-        args?.handled = true
-        openInNewTabRequested = false
-
-        let queued = (try? dispatcherQueue?.tryEnqueue { [weak self] in
-            guard let self else { return }
-            _ = self.navigate(
-                to: url,
-                mode: .newTab,
-                transitionInfoOverride: SuppressNavigationTransitionInfo()
-            )
-        }) ?? false
-
-        if !queued {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                _ = self.navigate(
-                    to: url,
-                    mode: .newTab,
-                    transitionInfoOverride: SuppressNavigationTransitionInfo()
-                )
-            }
-        }
-    }
-
-    private func isNavigationItemSelected(_ item: NavigationViewItemBase) -> Bool {
-        guard let selectedItem = navigationView.selectedItem as? NavigationViewItemBase else { return false }
-        return selectedItem === item
-    }
-
-    private func url(for item: NavigationViewItemBase) -> URL? {
-        guard
-            let navItem = item as? NavigationViewItem,
-            let tag = navItem.tag,
-            let str = tag as? HString
-        else {
-            return nil
-        }
-
-        return URL(string: String(hString: str))
-    }
-
-    private func applyAppearance() {
-        // 死窗口防御：closed handler 把 viewModel 置为 nil，此时 appWindow 也已失效（IUO → nil）
-        guard viewModel != nil, appWindow != nil else { return }
-        // 防止并发/重入（多窗口下 env Observation 接连触发可能引发 menuItems 的双 parent 错误）
-        guard !isApplyingAppearance else { return }
-        isApplyingAppearance = true
-        defer { isApplyingAppearance = false }
-
-        // For min/max/close buttons. 目前不支持材质效果，但比逐个设置按钮颜色简单，并且容易由框架修正。
-        self.appWindow.titleBar.preferredTheme = App.context.theme.titleBarTheme
-
-        self.title = tr(App.context.productName)
-        titleBar.title = self.title
-        searchBox?.placeholderText = tr("searchControlsAndSamples")
-
-        let context = WindowContext(owner: self)
-        titleBarRightHeader.children.clear()
-        navigationView.menuItems.clear()
-        navigationView.footerMenuItems.clear()
-        for module in App.context.modules {
-            if let item = module.titleBarRightHeaderItemRequired(in: context) {
-                titleBarRightHeader.children.append(item)
-            }
-            for item in module.navigationViewMenuItemsRequired(in: context) {
-                appendNavigationItem(item, false)
-            }
-            for item in module.navigationViewFooterMenuItemsRequired(in: context) {
-                appendNavigationItem(item, true)
-            }
-        }
-
-        if let url = initialNavigationURL {
-            initialNavigationURL = nil
-            _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
-            return
-        }
-
-        if let page = viewModel.currentPage {
-            navigate(to: page)
-        } else if let lastURL = viewModel.routePreferences.lastPageURL, navigate(to: lastURL) {
-            return
-        } else {
-            navigationView.selectFirstItem()
-        }
-    }
-    
-    private func restoreWindowRect() {
-        guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter
-        else { return }
-
-        let maximized = viewModel.windowPosition.isMaximized //moveAndResize will cause pref changed in event, so need to reserve here
-        try? hwnd.moveAndResize(viewModel.windowPosition.windowRect)
-        if maximized {
-            try? presenter.maximize()
-        }
-    }
-
-    private func trackWindowSize() {
-        guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter else { return }
-
-        if presenter.state == .restored {
-            viewModel.windowPosition.windowWidth = Int(hwnd.size.width)
-            viewModel.windowPosition.windowHeight = Int(hwnd.size.height)
-            viewModel.windowPosition.isMaximized = false
-        } else if presenter.state == .maximized {
-            viewModel.windowPosition.isMaximized = true
-        }
-    }
-
-    private func trackWindowPosition() {
-        guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter
-        else { return }
-
-        if presenter.state == .restored {
-            viewModel.windowPosition.windowX = Int(hwnd.position.x)
-            viewModel.windowPosition.windowY = Int(hwnd.position.y)
-        }
-    }
-
-    // MARK: - Splitter Methods
-
-    private func makeSplitterBorder() -> Border {
-        let b = Border()
-        b.width = splitterWidth
-        b.verticalAlignment = .stretch
-        b.horizontalAlignment = .left
-        b.background = SolidColorBrush(UWP.Color(a: 0, r: 0, g: 0, b: 0)) // transparent hit area
-        b.margin = Thickness(
-            left: navigationView.openPaneLength - splitterWidth / 2,
-            top: 0, right: 0, bottom: 0
-        )
-        b.visibility = viewModel.windowLayout.navigationViewPaneOpen ? .visible : .collapsed
-        b.protectedCursor = try? InputSystemCursor.create(.sizeWestEast)
-
-        setupSplitterPointerEvents(b)
-        return b
-    }
-
-    private func setupSplitterPointerEvents(_ splitter: Border) {
-        splitter.pointerPressed.addHandler { [weak self] _, args in
-            guard let self, let args else { return }
-            let point = try? args.getCurrentPoint(nil) // window-relative
-            self.isDraggingSplitter = true
-            self.dragStartX = Double(point?.position.x ?? 0)
-            self.dragStartPaneLength = self.navigationView.openPaneLength
-            _ = try? self.splitterBorder.capturePointer(args.pointer)
-            args.handled = true
-        }
-
-        splitter.pointerMoved.addHandler { [weak self] _, args in
-            guard let self, self.isDraggingSplitter, let args else { return }
-            let point = try? args.getCurrentPoint(nil) // window-relative
-            let currentX = Double(point?.position.x ?? 0)
-            let delta = currentX - self.dragStartX
-            let newLength = min(self.viewModel.windowLayout.navigationViewMaxPaneLength, max(self.viewModel.windowLayout.navigationViewMinPaneLength, self.dragStartPaneLength + delta))
-            self.applyPaneLength(newLength)
-            args.handled = true
-        }
-
-        splitter.pointerReleased.addHandler { [weak self] _, args in
-            guard let self, let args else { return }
-            self.isDraggingSplitter = false
-            try? self.splitterBorder.releasePointerCapture(args.pointer)
-            args.handled = true
-        }
-
-        splitter.pointerCaptureLost.addHandler { [weak self] _, _ in
-            guard let self else { return }
-            self.isDraggingSplitter = false
-        }
-    }
-
-    private func applyPaneLength(_ length: Double) {
-        navigationView.openPaneLength = length
-        navigationView.expandedModeThresholdWidth = length + viewModel.windowLayout.navigationViewExpandedModeThresholdContentWidth
-        splitterBorder.margin = Thickness(
-            left: length - splitterWidth / 2,
-            top: 0, right: 0, bottom: 0
-        )
     }
 }

--- a/Sources/RsUI/App/MainWindow/MainWindowModels.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowModels.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UWP
 import RsHelper
 
 struct WindowPosition: Preferable {
@@ -21,4 +22,15 @@ struct WindowLayout: Preferable {
 struct RoutePreferences: Preferable {
     var maxHistoryPages: Int = 32
     var lastPageURL: URL? = nil
+}
+
+extension WindowPosition {
+    var windowRect: UWP.RectInt32 {
+        return UWP.RectInt32(
+            x: Int32(windowX),
+            y: Int32(windowY),
+            width: Int32(windowWidth),
+            height: Int32(windowHeight)
+        )
+    }
 }

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -151,6 +151,13 @@ class MainWindowViewModel {
         navigationRevision += 1
     }
 
+    func closeOtherTabs() {
+        guard let tab = selectedTab, tabs.count > 1 else { return }
+        tabs = [tab]
+        syncLegacyHistory()
+        navigationRevision += 1
+    }
+
     func dumpHistory() {
         for (index, page) in (selectedTab?.backwardPages ?? []).enumerated() {
             log.info("\(index) <===\(page.url)")

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -92,7 +92,12 @@ class MainWindowViewModel {
     }
 
     @discardableResult
-    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil, inNewTab: Bool = false) -> MainWindowTab {
+    func navigate(
+        to page: Page,
+        transitionInfoOverride: NavigationTransitionInfo? = nil,
+        inNewTab: Bool = false,
+        switchToTab: Bool = true
+    ) -> MainWindowTab {
         let tab: MainWindowTab
         if inNewTab || selectedTab == nil {
             tab = addTab(for: page, transitionInfoOverride: transitionInfoOverride)
@@ -105,8 +110,12 @@ class MainWindowViewModel {
             )
         }
 
-        selectedTab = tab
-        routePreferences.lastPageURL = page.url
+        // 后台新 tab（switchToTab == false）保持原选中 tab 不变；
+        // 第一次开 tab（selectedTab 之前为 nil）必须切过去否则没有可显示的 tab。
+        if switchToTab || selectedTab == nil {
+            selectedTab = tab
+            routePreferences.lastPageURL = page.url
+        }
         syncLegacyHistory()
         navigationRevision += 1
         return tab

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -3,16 +3,81 @@ import Observation
 import WinUI
 import RsHelper
 
+class MainWindowTab {
+    var backwardPages: [Page] = []
+    var forwardPages: [Page] = []
+    var currentPage: Page? = nil
+    var navigationTransitionInfo: NavigationTransitionInfo? = nil
+    var needsRender: Bool = false
+
+    init(page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        navigate(to: page, transitionInfoOverride: transitionInfoOverride)
+    }
+
+    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil, maxHistoryPages: Int) {
+        navigationTransitionInfo = transitionInfoOverride
+        needsRender = true
+        if currentPage === page {
+            currentPage = page
+        } else {
+            if let previousPage = currentPage {
+                backwardPages.append(previousPage)
+                if backwardPages.count > maxHistoryPages {
+                    backwardPages.removeFirst()
+                }
+            }
+            currentPage = page
+            forwardPages.removeAll()
+        }
+    }
+
+    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        navigationTransitionInfo = transitionInfoOverride
+        currentPage = page
+        needsRender = true
+    }
+
+    func goBack(_ transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        guard !backwardPages.isEmpty else { return }
+
+        navigationTransitionInfo = transitionInfoOverride
+        needsRender = true
+        if let page = currentPage {
+            forwardPages.append(page)
+        }
+        currentPage = backwardPages.removeLast()
+    }
+
+    func goForward(_ transitionInfoOverride: NavigationTransitionInfo? = nil) {
+        guard !forwardPages.isEmpty else { return }
+
+        navigationTransitionInfo = transitionInfoOverride
+        needsRender = true
+        if let page = currentPage {
+            backwardPages.append(page)
+        }
+        currentPage = forwardPages.removeLast()
+    }
+}
+
 @Observable
 class MainWindowViewModel {
     var windowPosition: WindowPosition
     var windowLayout: WindowLayout
     var routePreferences: RoutePreferences
 
+    var tabs: [MainWindowTab] = []
+    var selectedTab: MainWindowTab? = nil
+    var navigationRevision: Int = 0
+
     var backwardPages: [Page] = []
     var forwardPages: [Page] = []
-    var currentPage: Page? = nil
-    var navigationTransitionInfo: NavigationTransitionInfo? = nil
+    var currentPage: Page? {
+        selectedTab?.currentPage
+    }
+    var navigationTransitionInfo: NavigationTransitionInfo? {
+        selectedTab?.navigationTransitionInfo
+    }
 
     init() {
         windowPosition = App.context.preferences.load(for: WindowPosition.self)
@@ -26,54 +91,86 @@ class MainWindowViewModel {
         App.context.preferences.save(routePreferences)
     }
 
-    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
-        navigationTransitionInfo = transitionInfoOverride
-        if (currentPage === page) { // For refresh current page by appearance change etc.
-            currentPage = page
+    @discardableResult
+    func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil, inNewTab: Bool = false) -> MainWindowTab {
+        let tab: MainWindowTab
+        if inNewTab || selectedTab == nil {
+            tab = addTab(for: page, transitionInfoOverride: transitionInfoOverride)
         } else {
-            if let previousPage = currentPage {
-                backwardPages.append(previousPage)
-                if backwardPages.count > routePreferences.maxHistoryPages {
-                    backwardPages.removeFirst()
-                }
-            }
-            currentPage = page
-            forwardPages.removeAll()
-            routePreferences.lastPageURL = page.url
+            tab = selectedTab!
+            tab.navigate(
+                to: page,
+                transitionInfoOverride: transitionInfoOverride,
+                maxHistoryPages: routePreferences.maxHistoryPages
+            )
         }
+
+        selectedTab = tab
+        routePreferences.lastPageURL = page.url
+        syncLegacyHistory()
+        navigationRevision += 1
+        return tab
     }
 
     func goBack(_ transitionInfoOverride: NavigationTransitionInfo? = nil) {
-        guard !backwardPages.isEmpty else { return }
+        guard let selectedTab, !selectedTab.backwardPages.isEmpty else { return }
 
-        navigationTransitionInfo = transitionInfoOverride
-        if let page = currentPage {
-            forwardPages.append(page)
-        }
-        currentPage = backwardPages.removeLast()
+        selectedTab.goBack(transitionInfoOverride)
         routePreferences.lastPageURL = currentPage?.url
+        syncLegacyHistory()
+        navigationRevision += 1
     }
 
     func goForward(_ transitionInfoOverride: NavigationTransitionInfo? = nil) {
-        guard !forwardPages.isEmpty else { return }
+        guard let selectedTab, !selectedTab.forwardPages.isEmpty else { return }
 
-        navigationTransitionInfo = transitionInfoOverride
-        if let page = currentPage {
-            backwardPages.append(page)
-        }
-        currentPage = forwardPages.removeLast()
+        selectedTab.goForward(transitionInfoOverride)
         routePreferences.lastPageURL = currentPage?.url
+        syncLegacyHistory()
+        navigationRevision += 1
+    }
+
+    func select(tab: MainWindowTab) {
+        guard tabs.contains(where: { $0 === tab }) else { return }
+        selectedTab = tab
+        routePreferences.lastPageURL = tab.currentPage?.url
+        syncLegacyHistory()
+        navigationRevision += 1
+    }
+
+    func close(tab: MainWindowTab) {
+        guard tabs.count > 1, let index = tabs.firstIndex(where: { $0 === tab }) else { return }
+
+        let wasSelected = selectedTab === tab
+        tabs.remove(at: index)
+        if wasSelected {
+            selectedTab = tabs[min(index, tabs.count - 1)]
+            routePreferences.lastPageURL = selectedTab?.currentPage?.url
+        }
+        syncLegacyHistory()
+        navigationRevision += 1
     }
 
     func dumpHistory() {
-        for (index, page) in backwardPages.enumerated() {
+        for (index, page) in (selectedTab?.backwardPages ?? []).enumerated() {
             log.info("\(index) <===\(page.url)")
         }
         log.info("-----------------------------------------------")
         log.info("====\(currentPage?.url.absoluteString ?? "nil")")
         log.info("-----------------------------------------------")
-        for (index, page) in forwardPages.enumerated() {
+        for (index, page) in (selectedTab?.forwardPages ?? []).enumerated() {
             log.info("\(index) ===>\(page.url)")
         }
+    }
+
+    private func addTab(for page: Page, transitionInfoOverride: NavigationTransitionInfo?) -> MainWindowTab {
+        let tab = MainWindowTab(page: page, transitionInfoOverride: transitionInfoOverride)
+        tabs.append(tab)
+        return tab
+    }
+
+    private func syncLegacyHistory() {
+        backwardPages = selectedTab?.backwardPages ?? []
+        forwardPages = selectedTab?.forwardPages ?? []
     }
 }

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -158,6 +158,29 @@ class MainWindowViewModel {
         navigationRevision += 1
     }
 
+    /// Removes a tab for transfer to another window; unlike close(tab:), allows removing with only 1 tab remaining.
+    func detachTab(_ tab: MainWindowTab) {
+        guard let index = tabs.firstIndex(where: { $0 === tab }) else { return }
+        let wasSelected = selectedTab === tab
+        tabs.remove(at: index)
+        if wasSelected {
+            selectedTab = tabs.isEmpty ? nil : tabs[min(index, tabs.count - 1)]
+            routePreferences.lastPageURL = selectedTab?.currentPage?.url
+        }
+        syncLegacyHistory()
+        navigationRevision += 1
+    }
+
+    /// Seeds this ViewModel with a tab transferred from another window.
+    func setTransferredTab(_ tab: MainWindowTab) {
+        tab.needsRender = true
+        tabs = [tab]
+        selectedTab = tab
+        routePreferences.lastPageURL = tab.currentPage?.url
+        syncLegacyHistory()
+        navigationRevision += 1
+    }
+
     func dumpHistory() {
         for (index, page) in (selectedTab?.backwardPages ?? []).enumerated() {
             log.info("\(index) <===\(page.url)")

--- a/Sources/RsUI/Models/NavigationOpenMode.swift
+++ b/Sources/RsUI/Models/NavigationOpenMode.swift
@@ -1,0 +1,12 @@
+/// 导航打开模式 —— 调用 `WindowContext.navigate` / `MainWindow.navigate` 时指定。
+///
+/// - inplace：在当前选中 Tab 内导航（默认行为）
+/// - newTab：打开为新 Tab 并切换过去
+/// - newTabBackground：打开为新 Tab 但**不**切换过去（类似浏览器 Ctrl+click）
+/// - newWindow：打开为新主窗口
+public enum NavigationOpenMode: Sendable {
+    case inplace
+    case newTab
+    case newTabBackground
+    case newWindow
+}

--- a/Sources/RsUI/Models/WindowContext.swift
+++ b/Sources/RsUI/Models/WindowContext.swift
@@ -18,11 +18,23 @@ public struct WindowContext {
         }
     }
 
-    public func navigate(to page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
-        owner.navigate(to: page, transitionInfoOverride: transitionInfoOverride)
+    /// 用指定模式打开页面。`mode` 默认 `.inplace`（当前 Tab 内导航）。
+    /// 模块可显式传 `.newTab` / `.newTabBackground` / `.newWindow` 选择行为。
+    public func navigate(
+        to page: Page,
+        mode: NavigationOpenMode = .inplace,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) {
+        owner.navigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
     }
 
-    public func navigate(to url: URL, transitionInfoOverride: NavigationTransitionInfo? = nil) -> Bool {
-        return owner.navigate(to: url, transitionInfoOverride: transitionInfoOverride)
+    /// URL 形式的导航；返回 `false` 表示没有任何模块识别该 URL。
+    @discardableResult
+    public func navigate(
+        to url: URL,
+        mode: NavigationOpenMode = .inplace,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Bool {
+        return owner.navigate(to: url, mode: mode, transitionInfoOverride: transitionInfoOverride)
     }
 }

--- a/Tests/RsUITests/MainWindowViewModelTests.swift
+++ b/Tests/RsUITests/MainWindowViewModelTests.swift
@@ -4,7 +4,12 @@ import WinUI
 @testable import RsUI
 
 private final class MockView: RsUI.Page {
-    let id = UUID().uuidString
+    let id: String
+
+    init(id: String = UUID().uuidString) {
+        self.id = id
+    }
+
     var url: URL { return URL(string: "rs://ui/mainwindow/test/\(id)")! }
 
     var content: WinUI.UIElement {
@@ -171,5 +176,93 @@ struct MainWindowViewModelTests {
         #expect(viewModel.forwardPages.isEmpty)
         #expect(viewModel.backwardPages.count == 1)
         #expect(viewModel.routePreferences.lastPageURL == view3.url)
+    }
+
+    // Requirement: normal navigation stays in the current tab and appends the previous page to that tab's back stack.
+    @Test
+    func navigateInCurrentTabKeepsOneTabAndAddsCurrentTabHistory() {
+        let viewModel = MainWindowViewModel()
+        let view1 = MockView()
+        let view2 = MockView()
+
+        viewModel.navigate(to: view1)
+        let firstTab = viewModel.selectedTab
+        viewModel.navigate(to: view2)
+
+        #expect(viewModel.tabs.count == 1)
+        #expect(viewModel.selectedTab === firstTab)
+        #expect(viewModel.currentPage === view2)
+        #expect(viewModel.backwardPages.count == 1)
+        #expect(viewModel.backwardPages[0] === view1)
+    }
+
+    // Requirement: Ctrl/open-in-new-tab navigation creates and selects a separate tab with an empty history stack.
+    @Test
+    func navigateInNewTabCreatesIndependentSelectedTab() {
+        let viewModel = MainWindowViewModel()
+        let view1 = MockView()
+        let view2 = MockView()
+
+        viewModel.navigate(to: view1)
+        let firstTab = viewModel.selectedTab
+        viewModel.navigate(to: view2, inNewTab: true)
+        let secondTab = viewModel.selectedTab
+
+        #expect(viewModel.tabs.count == 2)
+        #expect(firstTab !== secondTab)
+        #expect(firstTab?.currentPage === view1)
+        #expect(secondTab?.currentPage === view2)
+        #expect(secondTab?.backwardPages.isEmpty == true)
+        #expect(secondTab?.forwardPages.isEmpty == true)
+    }
+
+    // Requirement: the same URL can be opened in multiple independent tabs, matching browser duplicate-tab behavior.
+    @Test
+    func navigateSameURLInNewTabCreatesDuplicateIndependentTab() {
+        let viewModel = MainWindowViewModel()
+        let view1 = MockView(id: "same-url")
+        let view2 = MockView(id: "same-url")
+
+        viewModel.navigate(to: view1)
+        let firstTab = viewModel.selectedTab
+        viewModel.navigate(to: view2, inNewTab: true)
+        let secondTab = viewModel.selectedTab
+
+        #expect(viewModel.tabs.count == 2)
+        #expect(firstTab !== secondTab)
+        #expect(firstTab?.currentPage === view1)
+        #expect(secondTab?.currentPage === view2)
+        #expect(firstTab?.currentPage?.url == secondTab?.currentPage?.url)
+    }
+
+    // Requirement: switching tabs restores each tab's own back and forward history without sharing state.
+    @Test
+    func eachTabKeepsItsOwnBackForwardHistory() {
+        let viewModel = MainWindowViewModel()
+        let tab1Page1 = MockView()
+        let tab1Page2 = MockView()
+        let tab2Page1 = MockView()
+        let tab2Page2 = MockView()
+
+        viewModel.navigate(to: tab1Page1)
+        let firstTab = viewModel.selectedTab!
+        viewModel.navigate(to: tab1Page2)
+
+        viewModel.navigate(to: tab2Page1, inNewTab: true)
+        let secondTab = viewModel.selectedTab!
+        viewModel.navigate(to: tab2Page2)
+        viewModel.goBack()
+
+        viewModel.select(tab: firstTab)
+        #expect(viewModel.currentPage === tab1Page2)
+        #expect(viewModel.backwardPages.count == 1)
+        #expect(viewModel.backwardPages[0] === tab1Page1)
+        #expect(viewModel.forwardPages.isEmpty)
+
+        viewModel.select(tab: secondTab)
+        #expect(viewModel.currentPage === tab2Page1)
+        #expect(viewModel.backwardPages.isEmpty)
+        #expect(viewModel.forwardPages.count == 1)
+        #expect(viewModel.forwardPages[0] === tab2Page2)
     }
 }


### PR DESCRIPTION
## 背景

将 TabView 从 Page 内部移到顶层窗口（NavContent 区域），类似 Gallery 设计，并实现完整的多标签页交互能力。

## 变更范围

### TabView 基础架构

- 集成顶级 TabView：重构 `MainWindow`，将 `TabView` 放置在 NavContent顶层；每个 Tab 对应一个独立 `TabViewModel` 实例（含各自的 `backwardPages` / `forwardPages` 导航历史）。
- 单 Tab 时自动隐藏 Tab Title Bar；多于一个 Tab 时才显示。
- 第一个 Tab 锁定不可关闭。

实现 top-tabview 的方式其实并没有采用gallery中的host、tabview控制 visible 属性来完成多窗口，因为会涉及到更多的窗口创建和设计的问题。采用的方法是，顶部有一个没有内容的tabview，而tabview的内容交由host管理，类似navigationView和rootFrame之间的关系。

### 导航扩展

- `WindowContext.navigate` 新增 `NavigationOpenMode` 参数，支持三种模式：`inplace`（当前 Tab 内导航）、`newTab`（新 Tab 打开并切换）、`newWindow`（拖出为独立窗口）。新增 `Sources/RsUI/Models/NavigationOpenMode.swift`。
- 支持后台新 Tab 打开（不切换），类似浏览器 Ctrl+点击行为；增加点击 NavItem 时的 Ctrl 键标志传递。

### UI 细节

- Tab 内容区域全屏，去除多余边距。
- Tab Title Bar 与 NavContent 直接贴顶，无间隙。
- TabView Header 区域新增"关闭其他标签"按钮，点击后收拢为单 Tab 样式，同时规避 Win11 TabView 左侧双圆角视觉问题。

### tab dock功能

- Tab 拖出（tear-off）成新主窗口：拖出时 TabViewModel（含导航历史）随 Tab 迁移到新窗口；同步实现 Tab merge（将游离窗口合并回主窗口）。

### 重构

很明显地将所有职责放入到同一个mainwindow.swift中会导致极难的可读性，哪怕采用swift的extension特性其实还是有诸多问题，后续可能要进一步重构。

- 将过大的 `MainWindow.swift` 按功能拆分为 8 个 extension 文件，降低单文件复杂度：
  - `MainWindow+Content.swift` — 主内容区布局
  - `MainWindow+Navigation.swift` — 导航逻辑
  - `MainWindow+PageRendering.swift` — 页面渲染
  - `MainWindow+Splitter.swift` — 分栏处理
  - `MainWindow+TabFrames.swift` — Tab 帧管理
  - `MainWindow+TabInteraction.swift` — Tab 交互事件
  - `MainWindow+Tabs.swift` — Tab 增删逻辑
  - `MainWindow+WindowLifecycle.swift` — 窗口生命周期

### 测试

- `MainWindowViewModelTests` 新增/扩充多标签相关测试用例（Tab 增删、历史隔离、关闭策略等）。

## 测试方法

```
# 运行示例应用，手动验证：
# 1. 打开多个 Tab，验证 Tab Bar 显示/隐藏逻辑
# 2. 关闭第一个 Tab（应不可关闭）
# 3. 点击"关闭其他标签"按钮
# 4. 拖出 Tab 为独立窗口，再合并回来
# 5. Ctrl+点击 NavItem 在后台新 Tab 打开
```

## 讨论

### crush problem

在构建的过程中其实遇到了许多关于组件挂载的问题，会导致程序崩溃，哪怕是解决了比较明显的问题，但是可能仍然存在隐患。所以下一步我会构建出针对 multi-tab 更多的测试用例，并解决记录可能的崩溃问题，并将这些崩溃问题设计测试用例。

具体在fork仓库的 top-level-tabview-test分支工作。

```
1. 多窗口切换主题颜色、语言时候可能发生崩溃，有时settingsCard的边框不会换色。
2. 创建非常多的tab的时候可能会发生崩溃。
3. 拖出tab的时候可能崩溃。
......
```

### UI 设计

其实现有的UI还存在问题，无论是样式还是交互方式都需要进一步改进。

例如：我在 tear-off tab的过程中虽然加入了提示，但是 tabview 拖出的tab还是有不可脱出的样式。

例如：顶部的 tabview striper 的样式或许可以设计的更好看，更统一。


## 展示


<img width="3026" height="1702" alt="动画" src="https://github.com/user-attachments/assets/58a0e281-a724-475b-bfe8-44c7f256d203" />

