### PR TITLE
Add detached window APIs and gate tab tear-off behavior

### DIFF
--- a/Sources/RsUI/App/DetachedWindow.swift
+++ b/Sources/RsUI/App/DetachedWindow.swift
@@ -1,0 +1,103 @@
+import Foundation
+import WinAppSDK
+import WinUI
+
+/// Presentation mode used when showing a detached content window.
+public enum DetachedWindowPresentation: Sendable, Equatable {
+    /// Show as a normal overlapped window.
+    case windowed
+
+    /// Show as a fullscreen window.
+    case fullscreen
+}
+
+/// A shell-free RsUI window for hosting standalone content.
+///
+/// `DetachedWindow` is intended for content such as viewers, previews, or tools that
+/// need a plain WinUI `Window` without the RsUI `MainWindow` shell, NavigationView, or
+/// top-level TabView. The caller owns any domain state and can use `onClosed` to restore
+/// content back into an application tab. Keep a strong reference to the window for as
+/// long as it should remain available.
+public final class DetachedWindow: Window {
+    private let onClosed: (() -> Void)?
+    private var didNotifyClosed = false
+    private var fullscreenPresentation = false
+
+    /// Indicates whether this window was most recently put into fullscreen presentation.
+    public var isFullscreenPresentation: Bool {
+        fullscreenPresentation
+    }
+
+    /// Creates a shell-free window that hosts the supplied content.
+    ///
+    /// - Parameters:
+    ///   - title: Optional window title.
+    ///   - content: The content to assign to `Window.content`.
+    ///   - onClosed: Optional callback invoked exactly once when the window closes.
+    public init(
+        title: String? = nil,
+        content: UIElement,
+        onClosed: (() -> Void)? = nil
+    ) {
+        self.onClosed = onClosed
+        super.init()
+
+        self.content = content
+        if let title {
+            appWindow.title = title
+        }
+        closed.addHandler { [weak self] _, _ in
+            self?.notifyClosedIfNeeded()
+        }
+    }
+
+    /// Activates the window without changing its current presentation kind.
+    public func activateWindow() {
+        try? activate()
+    }
+
+    /// Opens the window using the requested presentation.
+    public func open(_ presentation: DetachedWindowPresentation = .windowed) {
+        switch presentation {
+        case .windowed:
+            openWindowed()
+        case .fullscreen:
+            openFullscreen()
+        }
+    }
+
+    /// Opens the window as a normal overlapped window.
+    public func openWindowed() {
+        try? activate()
+        restoreWindowed()
+    }
+
+    /// Opens the window as a fullscreen window.
+    public func openFullscreen() {
+        try? activate()
+        enterFullscreen()
+    }
+
+    /// Switches the window into fullscreen presentation.
+    public func enterFullscreen() {
+        try? appWindow.setPresenter(.fullScreen)
+        fullscreenPresentation = true
+    }
+
+    /// Switches the window back to normal overlapped presentation.
+    public func restoreWindowed() {
+        try? appWindow.setPresenter(.overlapped)
+        fullscreenPresentation = false
+    }
+
+    /// Closes the window. `onClosed` will be invoked from the closed event.
+    public func closeWindow() {
+        try? close()
+    }
+
+    private func notifyClosedIfNeeded() {
+        guard !didNotifyClosed else { return }
+        didNotifyClosed = true
+        onClosed?()
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
@@ -22,7 +22,9 @@ extension MainWindow {
 
         configureNavigationViewSelection()
         configureTabViewEvents()
-        setupTabDragHint()
+        if MainWindow.isTabTearOffMergeEnabled {
+            setupTabDragHint()
+        }
         configurePaneEvents()
 
         let navWrapper = makeNavigationWrapper()
@@ -65,7 +67,9 @@ extension MainWindow {
             self?.openNewTabFromTabStrip()
         }
 
-        // Source: record which tab is being dragged and expose it via static state for cross-window drop
+        guard MainWindow.isTabTearOffMergeEnabled else { return }
+
+        // Source: record which tab is being dragged and expose it via static state for cross-window drop.
         tabView.tabDragStarting.addHandler { [weak self] _, args in
             guard let self, let args, let item = args.tab else { return }
             guard let tab = self.tab(for: item) else { return }
@@ -74,12 +78,12 @@ extension MainWindow {
             MainWindow.activeDrag = DragState(sourceWindowID: ObjectIdentifier(self), tabURL: url)
         }
 
-        // Source: flag that the tab was physically dropped outside (vs drag cancelled by Escape)
+        // Source: flag that the tab was physically dropped outside (vs drag cancelled by Escape).
         tabView.tabDroppedOutside.addHandler { [weak self] _, _ in
             self?.dragDroppedOutside = true
         }
 
-        // Source: decide outcome once drag completes
+        // Source: decide outcome once drag completes.
         tabView.tabDragCompleted.addHandler { [weak self] _, args in
             guard let self, let args else { return }
             let wasDroppedOutside = self.dragDroppedOutside
@@ -93,20 +97,18 @@ extension MainWindow {
             guard self.viewModel.tabs.contains(where: { $0 === tab }) else { return }
 
             if args.dropResult == .none {
-                // No valid drop target accepted the drag; tear-off only when physically dropped (not Escape)
                 guard wasDroppedOutside else { return }
                 let url = tab.currentPage?.url
                 self.viewModel.close(tab: tab)
                 self.renderSelectedTab()
                 if let url { MainWindow.openDetachedWindow(navigatingTo: url) }
             } else {
-                // Another window's TabView accepted the drop; close the tab from this window
                 self.viewModel.close(tab: tab)
                 self.renderSelectedTab()
             }
         }
 
-        // Destination: accept tab drops from other windows' TabViews
+        // Destination: accept tab drops from other windows' TabViews.
         tabView.dragOver.addHandler { [weak self] _, args in
             guard let self, let args else { return }
             guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }

--- a/Sources/RsUI/App/MainWindow/MainWindow+Navigation.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Navigation.swift
@@ -40,7 +40,7 @@ extension MainWindow {
         transitionInfoOverride: NavigationTransitionInfo?
     ) {
         if mode == .newWindow {
-            MainWindow.openDetachedWindow(navigatingTo: page.url)
+            MainWindow.openDetachedWindow(opening: page, transitionInfoOverride: transitionInfoOverride)
             return
         }
         viewModel.navigate(
@@ -59,7 +59,7 @@ extension MainWindow {
         transitionInfoOverride: NavigationTransitionInfo?
     ) -> Bool {
         if mode == .newWindow {
-            MainWindow.openDetachedWindow(navigatingTo: url)
+            MainWindow.openDetachedWindow(navigatingTo: url, transitionInfoOverride: transitionInfoOverride)
             return true
         }
         // 仅在 inplace 模式下短路；其他模式（newTab / newTabBackground）允许重复打开同 URL

--- a/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
@@ -86,9 +86,60 @@ extension MainWindow {
         }
     }
 
-    static func openDetachedWindow(navigatingTo url: URL) {
+    func focusTab(matchingURL url: URL) -> Bool {
+        guard let tab = viewModel.findTab(matchingURL: url) else { return false }
+        switchToTab(tab)
+        return true
+    }
+
+    func detachCurrentTab() -> DetachedTabInfo? {
+        guard let currentTab = viewModel.selectedTab else { return nil }
+        guard let index = viewModel.tabs.firstIndex(where: { $0 === currentTab }) else { return nil }
+        guard let url = currentTab.currentPage?.url else { return nil }
+        viewModel.detachTab(currentTab)
+        renderSelectedTab()
+        return DetachedTabInfo(url: url, index: index)
+    }
+
+    func insertTab(
+        _ page: Page,
+        atIndex index: Int? = nil,
+        switchToTab: Bool = true,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) {
+        viewModel.addTab(
+            at: index,
+            for: page,
+            transitionInfoOverride: transitionInfoOverride,
+            switchToTab: switchToTab
+        )
+        renderSelectedTab()
+    }
+
+    static func openDetachedWindow(
+        navigatingTo url: URL,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) {
         let window = MainWindow()
         window.initialNavigationURL = url
+        window.initialNavigationTransitionInfoOverride = transitionInfoOverride
+        try? window.activate()
+    }
+
+    static func openDetachedWindow(
+        opening page: Page,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) {
+        openDetachedWindow(transitionInfoOverride: transitionInfoOverride) { _ in page }
+    }
+
+    static func openDetachedWindow(
+        transitionInfoOverride: NavigationTransitionInfo? = nil,
+        makePage: @escaping (WindowContext) -> Page
+    ) {
+        let window = MainWindow()
+        window.initialPageFactory = makePage
+        window.initialNavigationTransitionInfoOverride = transitionInfoOverride
         try? window.activate()
     }
 }

--- a/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
@@ -93,9 +93,19 @@ extension MainWindow {
             }
         }
 
+        if let makeInitialPage = initialPageFactory {
+            initialPageFactory = nil
+            let transitionInfoOverride = initialNavigationTransitionInfoOverride ?? SuppressNavigationTransitionInfo()
+            initialNavigationTransitionInfoOverride = nil
+            navigate(to: makeInitialPage(context), transitionInfoOverride: transitionInfoOverride)
+            return
+        }
+
         if let url = initialNavigationURL {
             initialNavigationURL = nil
-            _ = navigate(to: url, transitionInfoOverride: SuppressNavigationTransitionInfo())
+            let transitionInfoOverride = initialNavigationTransitionInfoOverride ?? SuppressNavigationTransitionInfo()
+            initialNavigationTransitionInfoOverride = nil
+            _ = navigate(to: url, transitionInfoOverride: transitionInfoOverride)
             return
         }
 

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -20,6 +20,7 @@ class MainWindow: Window {
 
     var openInNewTabRequested: Bool = false
     var initialNavigationURL: URL? = nil
+    static var isTabTearOffMergeEnabled = false
     var tabDragHintBorder: Border? = nil
     var draggingTabForDrop: MainWindowTab? = nil
     var dragDroppedOutside = false
@@ -180,7 +181,9 @@ class MainWindow: Window {
         tabs.margin = Thickness(left: 0, top: -1, right: 0, bottom: 0)
         tabs.canDragTabs = true
         tabs.canReorderTabs = true
-        tabs.allowDrop = true
+        tabs.allowDropTabs = true
+        tabs.canTearOutTabs = false
+        tabs.allowDrop = MainWindow.isTabTearOffMergeEnabled
         return tabs
     } ()
     lazy var tabContentHost = Grid()

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -20,6 +20,8 @@ class MainWindow: Window {
 
     var openInNewTabRequested: Bool = false
     var initialNavigationURL: URL? = nil
+    var initialPageFactory: ((WindowContext) -> Page)? = nil
+    var initialNavigationTransitionInfoOverride: NavigationTransitionInfo? = nil
     static var isTabTearOffMergeEnabled = false
     var tabDragHintBorder: Border? = nil
     var draggingTabForDrop: MainWindowTab? = nil

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -139,6 +139,32 @@ class MainWindowViewModel {
         navigationRevision += 1
     }
 
+    func findTab(matchingURL url: URL) -> MainWindowTab? {
+        tabs.first { $0.currentPage?.url == url }
+    }
+
+    @discardableResult
+    func addTab(
+        at index: Int? = nil,
+        for page: Page,
+        transitionInfoOverride: NavigationTransitionInfo? = nil,
+        switchToTab: Bool = true
+    ) -> MainWindowTab {
+        let tab = MainWindowTab(page: page, transitionInfoOverride: transitionInfoOverride)
+        if let index, index >= 0, index <= tabs.count {
+            tabs.insert(tab, at: index)
+        } else {
+            tabs.append(tab)
+        }
+        if switchToTab || selectedTab == nil {
+            selectedTab = tab
+            routePreferences.lastPageURL = page.url
+        }
+        syncLegacyHistory()
+        navigationRevision += 1
+        return tab
+    }
+
     func select(tab: MainWindowTab) {
         guard tabs.contains(where: { $0 === tab }) else { return }
         selectedTab = tab

--- a/Sources/RsUI/Models/NavigationOpenMode.swift
+++ b/Sources/RsUI/Models/NavigationOpenMode.swift
@@ -1,9 +1,9 @@
-/// 导航打开模式 —— 调用 `WindowContext.navigate` / `MainWindow.navigate` 时指定。
+/// Opening destination used by `WindowContext.open` and `MainWindow.navigate`.
 ///
-/// - inplace：在当前选中 Tab 内导航（默认行为）
-/// - newTab：打开为新 Tab 并切换过去
-/// - newTabBackground：打开为新 Tab 但**不**切换过去（类似浏览器 Ctrl+click）
-/// - newWindow：打开为新主窗口
+/// - inplace: Open in the currently selected tab.
+/// - newTab: Open in a new tab and switch to it.
+/// - newTabBackground: Open in a new tab without switching to it.
+/// - newWindow: Open in a new main window.
 public enum NavigationOpenMode: Sendable {
     case inplace
     case newTab

--- a/Sources/RsUI/Models/WindowContext.swift
+++ b/Sources/RsUI/Models/WindowContext.swift
@@ -2,11 +2,39 @@ import Foundation
 import WinAppSDK
 import WinUI
 
-/// Window context exposed to modules.
-public struct WindowContext {
-    let owner: MainWindow
+/// Information returned when a selected tab is detached from a main window.
+public struct DetachedTabInfo: Sendable {
+    /// The page URL that identified the detached tab.
+    public let url: URL
 
+    /// The tab's original 0-based position in the source tab strip.
+    public let index: Int
+}
+
+/// Window-scoped services exposed to RsUI modules and pages.
+///
+/// A `WindowContext` lets module code open pages, create tabs or windows,
+/// and use window-owned UI services without exposing `MainWindow` as public API.
+public struct WindowContext {
+    // Modules may keep this context from a Page, so the underlying window owner is weak.
+    weak var owner: MainWindow?
+
+    /// Opens the system folder picker owned by this window.
+    ///
+    /// Use this when module UI needs a folder path selected by the user. The picker is
+    /// associated with the current `MainWindow`, so the dialog is parented to the right
+    /// WinUI window.
+    ///
+    /// - Parameter handler: Called on the main actor with the selected folder path.
+    ///
+    /// Example:
+    /// ```swift
+    /// context.pickFolder { path in
+    ///     print("Selected folder: \(path)")
+    /// }
+    /// ```
     public func pickFolder(_ handler: @escaping (String) -> Void) {
+        guard let owner else { return }
         Task { @MainActor in
             let picker = FolderPicker(owner.appWindow.id)
             guard let asyncResult = try? picker.pickSingleFolderAsync() else { return }
@@ -18,23 +46,204 @@ public struct WindowContext {
         }
     }
 
-    /// 用指定模式打开页面。`mode` 默认 `.inplace`（当前 Tab 内导航）。
-    /// 模块可显式传 `.newTab` / `.newTabBackground` / `.newWindow` 选择行为。
-    public func navigate(
-        to page: Page,
+    /// Opens a page with the requested mode.
+    ///
+    /// Use this overload when the caller already has a `Page` instance. The page is
+    /// inserted directly into the selected destination and does not need to be routable
+    /// from a URL.
+    ///
+    /// - Parameters:
+    ///   - page: The page instance to display. For `.newWindow`, the page is displayed
+    ///     directly in the new window and does not need to be routable from a URL. If
+    ///     the page stores a `WindowContext`, make sure it is valid for the destination
+    ///     window; otherwise prefer `open(mode:makePage:)`.
+    ///   - mode: Where to open the page. `.inplace` replaces the selected tab content,
+    ///     `.newTab` creates and selects a tab, `.newTabBackground` creates a tab
+    ///     without selecting it, and `.newWindow` opens a new main window.
+    ///   - transitionInfoOverride: Optional WinUI navigation transition to use when the
+    ///     destination renders the page.
+    ///
+    /// Example:
+    /// ```swift
+    /// context.open(DetailsPage(itemID: id), mode: .newTab)
+    /// context.open(StaticPreviewPage(model: model), mode: .newWindow)
+    /// ```
+    public func open(
+        _ page: Page,
         mode: NavigationOpenMode = .inplace,
         transitionInfoOverride: NavigationTransitionInfo? = nil
     ) {
-        owner.navigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
+        owner?.navigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
     }
 
-    /// URL 形式的导航；返回 `false` 表示没有任何模块识别该 URL。
+    /// Opens a URL with the requested mode.
+    ///
+    /// Use this overload when the target page can be reconstructed from a URL through a
+    /// module's `navigationRequested(for:in:)` implementation. The URL does not need to
+    /// be represented by a NavigationView item, but it must be handled by Settings or by
+    /// a registered module.
+    ///
+    /// - Parameters:
+    ///   - url: The route URL to resolve.
+    ///   - mode: Where to open the resolved page. `.inplace` replaces the selected tab
+    ///     content, `.newTab` creates and selects a tab, `.newTabBackground` creates a
+    ///     tab without selecting it, and `.newWindow` opens a new main window.
+    ///   - transitionInfoOverride: Optional WinUI navigation transition to use when the
+    ///     destination renders the resolved page.
+    ///
+    /// - Returns: `true` if the route was accepted in the current window. For
+    ///   `.newWindow`, `true` means the new window request was issued.
+    ///
+    /// Example:
+    /// ```swift
+    /// _ = context.open(
+    ///     URL(string: "rs://arbitrary/window-context-result?id=42")!,
+    ///     mode: .newTabBackground
+    /// )
+    /// ```
     @discardableResult
-    public func navigate(
-        to url: URL,
+    public func open(
+        _ url: URL,
         mode: NavigationOpenMode = .inplace,
         transitionInfoOverride: NavigationTransitionInfo? = nil
     ) -> Bool {
+        return owner?.navigate(to: url, mode: mode, transitionInfoOverride: transitionInfoOverride) ?? false
+    }
+
+    /// Builds a page with the destination window context and opens it with the requested mode.
+    ///
+    /// Use this overload when the page should receive a `WindowContext` at construction
+    /// time. For `.inplace`, `.newTab`, and `.newTabBackground`, the target context
+    /// belongs to the current `MainWindow`. For `.newWindow`, RsUI creates the new
+    /// `MainWindow` first, then calls `makePage` with that destination window context.
+    ///
+    /// - Parameters:
+    ///   - mode: Where to open the generated page. `.inplace` replaces the selected tab
+    ///     content, `.newTab` creates and selects a tab, `.newTabBackground` creates a
+    ///     tab without selecting it, and `.newWindow` opens a new main window.
+    ///   - transitionInfoOverride: Optional WinUI navigation transition to use when the
+    ///     destination renders the page.
+    ///   - makePage: A synchronous factory that receives the destination window context
+    ///     and returns the page to display. The closure should create and return a
+    ///     `Page`; it should not perform long-running work.
+    ///
+    /// Example:
+    /// ```swift
+    /// context.open(mode: .newWindow) { windowContext in
+    ///     ViewerPage(context: windowContext, slideURL: slideURL)
+    /// }
+    /// ```
+    public func open(
+        mode: NavigationOpenMode,
+        transitionInfoOverride: NavigationTransitionInfo? = nil,
+        makePage: @escaping (WindowContext) -> Page
+    ) {
+        guard let owner else { return }
+        if mode == .newWindow {
+            MainWindow.openDetachedWindow(
+                transitionInfoOverride: transitionInfoOverride,
+                makePage: makePage
+            )
+            return
+        }
+
+        let context = WindowContext(owner: owner)
+        owner.navigate(
+            to: makePage(context),
+            mode: mode,
+            transitionInfoOverride: transitionInfoOverride
+        )
+    }
+
+    // MARK: - Open or Focus
+
+    /// Opens a URL in a new tab, or focuses the existing tab if one is already
+    /// displaying that URL.
+    ///
+    /// This is the primary "navigate-to-content" method for module code that
+    /// wants deduplication: slides, documents, detail views, etc. When a tab
+    /// with `url` already exists, it is selected and `true` is returned without
+    /// creating a duplicate. Otherwise a new tab is opened via the module's
+    /// `navigationRequested(for:in:)`.
+    ///
+    /// - Parameters:
+    ///   - url: The route URL to resolve.
+    ///   - mode: The fallback open mode when no existing tab is found.
+    ///     Defaults to `.newTab`. Only `.inplace`, `.newTab`, and
+    ///     `.newTabBackground` are meaningful (`.newWindow` is passed through
+    ///     to `open(_:mode:)` without deduplication).
+    ///   - focusExisting: Whether an existing matching tab should be selected.
+    ///     Pass `false` for background-open gestures that should avoid stealing focus.
+    ///   - transitionInfoOverride: Optional navigation transition for newly
+    ///     created tabs.
+    
+    /// - Returns: `true` if an existing tab was focused or a new navigation
+    ///   was accepted.
+    @discardableResult
+    public func openOrFocus(
+        _ url: URL,
+        mode: NavigationOpenMode = .newTab,
+        focusExisting: Bool = true,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Bool {
+        guard let owner else { return false }
+        if mode == .newWindow {
+            return owner.navigate(to: url, mode: mode, transitionInfoOverride: transitionInfoOverride)
+        }
+        if owner.viewModel.findTab(matchingURL: url) != nil {
+            if focusExisting {
+                _ = owner.focusTab(matchingURL: url)
+            }
+            return true
+        }
         return owner.navigate(to: url, mode: mode, transitionInfoOverride: transitionInfoOverride)
+    }
+
+    // MARK: - Detach / Restore
+
+    /// Removes the currently selected tab from this window for a caller-managed transfer.
+    ///
+    /// Use this after capturing any page runtime state needed by the destination host.
+    /// The method allows detaching the last tab; in that case the source window remains
+    /// open without a selected page until another tab is added or selected.
+    ///
+    /// - Returns: Information about the detached tab, or `nil` if the owner window has
+    ///   been released, no tab is selected, or the selected tab has no current page.
+    @discardableResult
+    public func detachCurrentTab() -> DetachedTabInfo? {
+        guard let owner else { return nil }
+        return owner.detachCurrentTab()
+    }
+
+    /// Restores caller-managed detached content into this window as a tab.
+    ///
+    /// Use this for "merge back from detached window" flows. The caller creates a
+    /// `Page` with restored runtime state and asks RsUI to insert it back into the tab
+    /// strip, typically at the index returned by `detachCurrentTab()`.
+    ///
+    /// - Parameters:
+    ///   - page: The page to display in the new tab.
+    ///   - preferredIndex: Preferred insertion position (0-based). If `nil` or out of
+    ///     range, the tab is appended to the end.
+    ///   - switchToTab: Whether to select the new tab. Defaults to `true`.
+    ///   - transitionInfoOverride: Optional navigation transition.
+    /// - Returns: `true` if the page was inserted. `false` if the owner window has
+    ///   already been released.
+    ///
+    @discardableResult
+    public func restoreDetachedTab(
+        _ page: Page,
+        preferredIndex: Int? = nil,
+        switchToTab: Bool = true,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Bool {
+        guard let owner else { return false }
+        owner.insertTab(
+            page,
+            atIndex: preferredIndex,
+            switchToTab: switchToTab,
+            transitionInfoOverride: transitionInfoOverride
+        )
+        return true
     }
 }


### PR DESCRIPTION
1. 禁止了 top level tabview 中的tear off和dock功能
2. 从RsUI开放更全面的接口给module使用，原有的navigate方法太过简单且没有完整的说明


## Changes

- Add `DetachedWindow`, a shell-free WinUI window wrapper for standalone content with windowed/fullscreen presentation and a one-shot close callback.
- Gate custom tab tear-off/merge behavior behind `MainWindow.isTabTearOffMergeEnabled`, and disable WinUI `TabView` tear-out by default.
- Replace public `WindowContext.navigate(...)` APIs with `open(...)` overloads for page, URL, and destination-context page factories.
- Add `WindowContext.openOrFocus(...)` for URL-based tab deduplication and optional focusing.
- Add `WindowContext.detachCurrentTab()` and `restoreDetachedTab(...)` for caller-managed tab transfer flows.
- Support opening new `MainWindow` instances from either a URL or a page factory, preserving transition overrides.


## Public API Notes

- `WindowContext.open(...)` is now the preferred public API for module navigation/opening.
- `WindowContext.openOrFocus(...)` is intended for content with stable URL identity, such as documents, viewers, or detail pages.
- `DetachedWindow` is available for modules that need a standalone content host without the full RsUI shell.
