### PR TITLE
feat: 让Page子类决定是否展示Page的Header和自定义top-tabview中的title

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
@@ -10,10 +10,12 @@ final class PageViewParts {
 extension MainWindow {
     func title(for page: Page?) -> String {
         guard let page else { return MainWindow.tr("New Tab") }
+        if let title = page.tabTitle, !title.isEmpty {
+            return title
+        }
         if let text = page.header as? String, !text.isEmpty {
             return text
         }
-
         let host = page.url.host ?? page.url.absoluteString
         return host.isEmpty ? page.url.absoluteString : host
     }
@@ -27,10 +29,11 @@ extension MainWindow {
         parts.headerBorder = nil
         tabPageViewPartsByID[tabID] = parts
 
-        // String header → 同时渲染为页面顶部 28pt 大标题 + 通过 title(for:) 用作 Tab 标签
+        // String header → 受 showPageHeader 控制是否渲染为页面顶部 28pt 大标题；tab 标签由 title(for:) 提供
         // UIElement header → 直接渲染到页面顶部
         let headerView: UIElement
         if let text = page.header as? String {
+            guard page.showPageHeader else { return page.content }
             let tb = TextBlock()
             tb.text = text
             tb.fontSize = 28

--- a/Sources/RsUI/Models/Page.swift
+++ b/Sources/RsUI/Models/Page.swift
@@ -5,11 +5,15 @@ import WinUI
 public protocol Page: AnyObject {
     var url: URL { get }
     var header: Any? { get }
+    var tabTitle: String? { get }
+    var showPageHeader: Bool { get }
     var content: UIElement { get }
 }
 
 public extension Page {
     var header: Any? { nil }
+    var tabTitle: String? { nil }
+    var showPageHeader: Bool { true }
 
     func startObserving<Element>(_ emit: @escaping @Sendable () -> Element, onChanged: @escaping @MainActor (Page, Element) -> Void) {
         let obs = Observations(emit)


### PR DESCRIPTION
切片浏览页面无需header, tab title显示切片名字就好。但以前的Page没考虑这种情况，可以调整一下；

以前实现的问题：

现有的逻辑是只有在没有Page.header的时候才不显示String Header，如果要tab-title展示的是PageImpl自定义名字则需要填入Page.header这个成员变量。

修改方案：

添加协议Page两个成员变量，tabTitle和showPageHeader，前者可以自定义top-tabview名称。若定义了则在makeview的时优先采用。
后者决定是否在页面中展示完全的content，不需要Page.Header的展示，方法是返回UIElement的时候直接返回Page.content，而不拼接Page.Header。


<img width="1912" height="387" alt="image" src="https://github.com/user-attachments/assets/5ef6ac33-bb1e-47cc-9a1b-78b0a5248250" />
