### PR TITLE
feature/page header tab title

### DIFF
--- a/Samples/SampleApp/ArbitraryModule/ArbitaryPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/ArbitaryPage.swift
@@ -9,6 +9,8 @@ final class ArbitaryPage: RsUI.Page {
         return URL(string: "rs://arbitrary")!
     }
 
+    var title: String { tr("Arbitrary Page") }
+
     var header: Any? {
         let container = StackPanel()
         container.padding = Thickness(left: 0, top: 0, right: 0, bottom: 32)

--- a/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
@@ -10,10 +10,12 @@ final class PageViewParts {
 extension MainWindow {
     func title(for page: Page?) -> String {
         guard let page else { return MainWindow.tr("New Tab") }
+        if let title = page.tabTitle, !title.isEmpty {
+            return title
+        }
         if let text = page.header as? String, !text.isEmpty {
             return text
         }
-
         let host = page.url.host ?? page.url.absoluteString
         return host.isEmpty ? page.url.absoluteString : host
     }
@@ -27,10 +29,11 @@ extension MainWindow {
         parts.headerBorder = nil
         tabPageViewPartsByID[tabID] = parts
 
-        // String header → 同时渲染为页面顶部 28pt 大标题 + 通过 title(for:) 用作 Tab 标签
+        // String header → 受 showPageHeader 控制是否渲染为页面顶部 28pt 大标题；tab 标签由 title(for:) 提供
         // UIElement header → 直接渲染到页面顶部
         let headerView: UIElement
         if let text = page.header as? String {
+            guard page.showPageHeader else { return page.content }
             let tb = TextBlock()
             tb.text = text
             tb.fontSize = 28

--- a/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+PageRendering.swift
@@ -9,15 +9,7 @@ final class PageViewParts {
 
 extension MainWindow {
     func title(for page: Page?) -> String {
-        guard let page else { return MainWindow.tr("New Tab") }
-        if let title = page.tabTitle, !title.isEmpty {
-            return title
-        }
-        if let text = page.header as? String, !text.isEmpty {
-            return text
-        }
-        let host = page.url.host ?? page.url.absoluteString
-        return host.isEmpty ? page.url.absoluteString : host
+        page?.title ?? MainWindow.tr("New Tab")
     }
 
     func makePageView(_ page: Page, for tab: MainWindowTab) -> UIElement {
@@ -29,11 +21,11 @@ extension MainWindow {
         parts.headerBorder = nil
         tabPageViewPartsByID[tabID] = parts
 
-        // String header → 受 showPageHeader 控制是否渲染为页面顶部 28pt 大标题；tab 标签由 title(for:) 提供
-        // UIElement header → 直接渲染到页面顶部
+        // String header: 渲染为页面顶部标题
+        // UIElement header: 直接渲染到页面顶部
+        // nil header: 不渲染 header 区域，content 占满整个页面
         let headerView: UIElement
         if let text = page.header as? String {
-            guard page.showPageHeader else { return page.content }
             let tb = TextBlock()
             tb.text = text
             tb.fontSize = 28

--- a/Sources/RsUI/App/Settings/SettingsPage.swift
+++ b/Sources/RsUI/App/Settings/SettingsPage.swift
@@ -15,6 +15,7 @@ class SettingsPage: Page {
     var url: URL {
         return SettingsPage.url
     }
+    var title: String { tr("title") }
     var header: Any? {
         return tr("title")
     }

--- a/Sources/RsUI/Models/Page.swift
+++ b/Sources/RsUI/Models/Page.swift
@@ -5,11 +5,15 @@ import WinUI
 public protocol Page: AnyObject {
     var url: URL { get }
     var header: Any? { get }
+    var tabTitle: String? { get }
+    var showPageHeader: Bool { get }
     var content: UIElement { get }
 }
 
 public extension Page {
     var header: Any? { nil }
+    var tabTitle: String? { nil }
+    var showPageHeader: Bool { true }
 
     func startObserving<Element>(_ emit: @escaping @Sendable () -> Element, onChanged: @escaping @MainActor (Page, Element) -> Void) {
         let obs = Observations(emit)

--- a/Sources/RsUI/Models/Page.swift
+++ b/Sources/RsUI/Models/Page.swift
@@ -5,15 +5,12 @@ import WinUI
 public protocol Page: AnyObject {
     var url: URL { get }
     var header: Any? { get }
-    var tabTitle: String? { get }
-    var showPageHeader: Bool { get }
+    var title: String { get }
     var content: UIElement { get }
 }
 
 public extension Page {
     var header: Any? { nil }
-    var tabTitle: String? { nil }
-    var showPageHeader: Bool { true }
 
     func startObserving<Element>(_ emit: @escaping @Sendable () -> Element, onChanged: @escaping @MainActor (Page, Element) -> Void) {
         let obs = Observations(emit)


### PR DESCRIPTION
这个PR是对 #45 的补充

移除了showPageHeader成员变量

移除 原tabTitle optional，要求Page子类必须实现

tabTitle 更换为 title

既然title属性必然存在，也就没有fallback设置的必要了，移除了title方法中的fallback


SettingsPage 和 ArbitraryPage的实现
