### PR TITLE
bugfix/close other button switch language and tear off hint language

### DIFF
--- a/Samples/Assets/Localizable.xcstrings
+++ b/Samples/Assets/Localizable.xcstrings
@@ -390,6 +390,23 @@
         }
       }
     },
+    "TabDragHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drag onto another window to merge, or release outside any window to detach it as a new window"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖到其他窗口可合并，拖到窗口外释放可分离为新窗口"
+          }
+        }
+      }
+    },
     "success" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
@@ -53,7 +53,7 @@ extension MainWindow {
 
     func setupTabDragHint() {
         let hintText = TextBlock()
-        hintText.text = MainWindow.tr("拖到其他窗口可合并，拖到窗口外释放可分离为新窗口")
+        hintText.text = MainWindow.tr("TabDragHint")
         hintText.fontSize = 12
         hintText.textWrapping = .wrap
         hintText.maxWidth = 460
@@ -75,6 +75,7 @@ extension MainWindow {
         try? Canvas.setZIndex(hintBorder, 99)
         tabContentHost.children.append(hintBorder)
         tabDragHintBorder = hintBorder
+        tabDragHintText = hintText
 
         tabView.tabDragStarting.addHandler { [weak hintBorder] _, _ in
             hintBorder?.visibility = .visible

--- a/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
@@ -78,6 +78,7 @@ extension MainWindow {
         self.title = MainWindow.tr(App.context.productName)
         titleBar.title = self.title
         searchBox?.placeholderText = MainWindow.tr("searchControlsAndSamples")
+        applyCloseOthersTooltip(to: closeOtherTabsButton)
 
         let context = WindowContext(owner: self)
         titleBarRightHeader.children.clear()

--- a/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
@@ -79,6 +79,7 @@ extension MainWindow {
         titleBar.title = self.title
         searchBox?.placeholderText = MainWindow.tr("searchControlsAndSamples")
         applyCloseOthersTooltip(to: closeOtherTabsButton)
+        tabDragHintText?.text = MainWindow.tr("TabDragHint")
 
         let context = WindowContext(owner: self)
         titleBarRightHeader.children.clear()

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -29,6 +29,8 @@ class MainWindow: Window {
     var suppressLayoutPersistence: Bool = false
     static var isTabTearOffMergeEnabled = false
     var tabDragHintBorder: Border? = nil
+    // 持有提示文本以便语言切换时重设（文本在 setupTabDragHint 创建时定格）
+    var tabDragHintText: TextBlock? = nil
     var draggingTabForDrop: MainWindowTab? = nil
     var dragDroppedOutside = false
 

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -130,11 +130,17 @@ class MainWindow: Window {
         btn.click.addHandler { [weak self] _, _ in
             self?.closeOtherTabs()
         }
-        let toolTip = ToolTip()
-        toolTip.content = MainWindow.tr("CloseOthers")
-        try? ToolTipService.setToolTip(btn, toolTip)
+        self.applyCloseOthersTooltip(to: btn)
         return btn
     }()
+
+    // tooltip 在按钮 lazy 求值时定格，语言切换后需重新应用本地化文案
+    func applyCloseOthersTooltip(to button: Button) {
+        let toolTip = ToolTip()
+        toolTip.content = MainWindow.tr("CloseOthers")
+        try? ToolTipService.setToolTip(button, toolTip)
+    }
+
     lazy var searchBox: AutoSuggestBox? = {
         // let box = AutoSuggestBox()
         // box.width = 360


### PR DESCRIPTION
## 问题

切换语言后，标签栏上两处本地化文本不更新，原因是文本只在控件首次创建时取一次 tr() 值。

## 方法

在语言切换的刷新入口 applyAppearance() 添加刷新这两处文本的语言。

1. tabview strip left header上的 close other button
2. tear off的提示也有这个问题



