### PR TITLE
fix(app): suppress auto Esc tooltip on fullscreen accelerator

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow+Fullscreen.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Fullscreen.swift
@@ -92,5 +92,9 @@ extension MainWindow {
             args?.handled = true
         }
         root.keyboardAccelerators.append(escAccelerator)
+
+        // WinUI auto-shows an "Esc" shortcut tooltip for elements owning a
+        // KeyboardAccelerator; suppress it since the accelerator is global.
+        root.keyboardAcceleratorPlacementMode = .hidden
     }
 }


### PR DESCRIPTION
因为快捷键KeyboardAccelerator挂载到rootGird中导致的显示ESC tooltip，现在抑制其出现，不影响ESC退出功能。