### PR TITLE
feat(tabs): native tab tear-out and merge

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
@@ -22,9 +22,6 @@ extension MainWindow {
 
         configureNavigationViewSelection()
         configureTabViewEvents()
-        if MainWindow.isTabTearOffMergeEnabled {
-            setupTabDragHint()
-        }
         configurePaneEvents()
 
         let navWrapper = makeNavigationWrapper()
@@ -72,55 +69,78 @@ extension MainWindow {
 
         guard MainWindow.isTabTearOffMergeEnabled else { return }
 
-        // Source: record which tab is being dragged and expose it via static state for cross-window drop.
-        tabView.tabDragStarting.addHandler { [weak self] _, args in
-            guard let self, let args, let item = args.tab else { return }
-            guard let tab = self.tab(for: item) else { return }
-            guard let url = tab.currentPage?.url else { return }
-            self.draggingTabForDrop = tab
-            MainWindow.activeDrag = DragState(sourceWindowID: ObjectIdentifier(self), tabURL: url)
-        }
+        // Native tear-out (CanTearOutTabs). The OS owns the drag visuals and the
+        // window-follow animation; these handlers only move our model — the
+        // MainWindowTab plus its decoupled content frame — between windows.
+        // Both the tab in flight and its receiving window are tracked in
+        // MainWindow.pendingTearOut. The receiver can't be read from the event:
+        // tabTearOutRequested gives args.newWindowId 0 even though we set it in
+        // the window-requested event, so we remember it ourselves, like the
+        // official CanTearOutTabs sample.
 
-        // Source: flag that the tab was physically dropped outside (vs drag cancelled by Escape).
-        tabView.tabDroppedOutside.addHandler { [weak self] _, _ in
-            self?.dragDroppedOutside = true
-        }
-
-        // Source: decide outcome once drag completes.
-        tabView.tabDragCompleted.addHandler { [weak self] _, args in
+        // A tab is being torn out and needs a window to land in. The framework
+        // over-fires this within one drag (incl. speculative tears it never
+        // commits), so tearOutReceiver() reuses one empty spare instead of
+        // leaking a window per call.
+        tabView.tabTearOutWindowRequested.addHandler { [weak self] _, args in
             guard let self, let args else { return }
-            let wasDroppedOutside = self.dragDroppedOutside
-            defer {
-                self.dragDroppedOutside = false
-                self.draggingTabForDrop = nil
-                MainWindow.activeDrag = nil
-            }
-            guard let tab = self.draggingTabForDrop else { return }
-            guard self.viewModel.tabs.count > 1 else { return }
-            guard self.viewModel.tabs.contains(where: { $0 === tab }) else { return }
-
-            if args.dropResult == .none {
-                guard wasDroppedOutside else { return }
-                let url = tab.currentPage?.url
-                self.viewModel.close(tab: tab)
-                self.renderSelectedTab()
-                if let url { MainWindow.openDetachedWindow(navigatingTo: url) }
-            } else {
-                self.viewModel.close(tab: tab)
-                self.renderSelectedTab()
-            }
+            // WinUI selects the pressed tab before the tear begins, so the
+            // selected tab is the one being torn out.
+            guard let tab = self.viewModel.selectedTab else { return }
+            let receiver = MainWindow.tearOutReceiver()
+            MainWindow.pendingTearOut = MainWindow.PendingTearOut(
+                tab: tab, holder: self, receiver: receiver
+            )
+            args.newWindowId = receiver.appWindow.id
         }
 
-        // Destination: accept tab drops from other windows' TabViews.
-        tabView.dragOver.addHandler { [weak self] _, args in
-            guard let self, let args else { return }
-            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
-            args.acceptedOperation = .move
+        // Commit the tear: move the torn tab from its holder into the
+        // receiver. Once moved, the spare is no longer empty, so release it.
+        tabView.tabTearOutRequested.addHandler { _, _ in
+            guard var pending = MainWindow.pendingTearOut,
+                  pending.holder !== pending.receiver else { return }
+            pending.holder.releaseTab(pending.tab)
+            pending.receiver.adoptTornTab(pending.tab)
+            pending.holder = pending.receiver
+            MainWindow.pendingTearOut = pending
+            MainWindow.spareReceiver = nil
         }
-        tabView.drop.addHandler { [weak self] _, _ in
-            guard let self else { return }
-            guard let drag = MainWindow.activeDrag, drag.sourceWindowID != ObjectIdentifier(self) else { return }
-            _ = self.navigate(to: drag.tabURL, mode: .newTab, transitionInfoOverride: SuppressNavigationTransitionInfo())
+
+        // A torn tab from another window is dragged over this strip — accept.
+        tabView.externalTornOutTabsDropping.addHandler { _, args in
+            guard let args, MainWindow.pendingTearOut != nil else { return }
+            args.allowDrop = true
+        }
+
+        // Merge: pull the torn tab from its current holder into this window at
+        // dropIndex, then discard the now-empty floating receiver.
+        tabView.externalTornOutTabsDropped.addHandler { [weak self] _, args in
+            guard let self, let args, let pending = MainWindow.pendingTearOut else { return }
+            let index = Int(args.dropIndex)
+            pending.holder.releaseTab(pending.tab)
+            self.adoptTornTab(pending.tab, at: index)
+            if pending.receiver !== self {
+                // Defer the close: when this handler returns the framework is
+                // still finalizing the drop on the receiver window, so closing it
+                // synchronously here crashes. Close on the next UI tick instead.
+                let receiver = pending.receiver
+                Task { @MainActor in receiver.closeIfEmpty() }
+            }
+            MainWindow.pendingTearOut = nil
+        }
+
+        // Persist an in-window reorder. Native tear-out suppresses
+        // tabDragCompleted, but a drag-reorder still mutates the TabItems
+        // collection directly, so tabItemsChanged is the only hook that sees it.
+        // A real tear-out also mutates the collection, but then a tab has LEFT
+        // this strip, so syncTabOrderFromStrip's count check bails: the strip
+        // must still hold exactly our model's tabs. That is what separates a
+        // reorder from a tear-out, not the tear flag. Skip only our own
+        // syncTabItems edits (isSyncingTabSelection); tabStripIDs stops the
+        // follow-up sync from looping.
+        tabView.tabItemsChanged.addHandler { [weak self] _, _ in
+            guard let self, !self.isSyncingTabSelection else { return }
+            self.syncTabOrderFromStrip()
         }
     }
 

--- a/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
@@ -51,40 +51,45 @@ extension MainWindow {
         renderSelectedTab()
     }
 
-    func setupTabDragHint() {
-        let hintText = TextBlock()
-        hintText.text = MainWindow.tr("TabDragHint")
-        hintText.fontSize = 12
-        hintText.textWrapping = .wrap
-        hintText.maxWidth = 460
-        hintText.foreground = SolidColorBrush(UWP.Color(a: 255, r: 245, g: 249, b: 255))
+    // MARK: - Native tear-out helpers
 
-        let hintBorder = Border()
-        hintBorder.background = SolidColorBrush(UWP.Color(a: 230, r: 21, g: 94, b: 175))
-        hintBorder.borderBrush = SolidColorBrush(UWP.Color(a: 255, r: 166, g: 215, b: 255))
-        hintBorder.borderThickness = Thickness(left: 1, top: 1, right: 1, bottom: 1)
-        hintBorder.cornerRadius = CornerRadius(topLeft: 10, topRight: 10, bottomRight: 10, bottomLeft: 10)
-        hintBorder.padding = Thickness(left: 12, top: 8, right: 12, bottom: 8)
-        hintBorder.horizontalAlignment = .center
-        hintBorder.verticalAlignment = .top
-        hintBorder.margin = Thickness(left: 0, top: 12, right: 0, bottom: 0)
-        hintBorder.opacity = 0
-        hintBorder.visibility = .collapsed
-        hintBorder.isHitTestVisible = false
-        hintBorder.child = hintText
-        try? Canvas.setZIndex(hintBorder, 99)
-        tabContentHost.children.append(hintBorder)
-        tabDragHintBorder = hintBorder
-        tabDragHintText = hintText
+    // Returns a window for the native tear-out to drop a tab into. Reuses the
+    // current empty spare if one exists (the framework asks repeatedly during a
+    // drag); otherwise creates and activates a fresh one so it owns a valid
+    // AppWindow.Id. The OS positions it as it follows the cursor.
+    static func tearOutReceiver() -> MainWindow {
+        if let spare = MainWindow.spareReceiver, spare.viewModel?.tabs.isEmpty ?? false {
+            return spare
+        }
+        let window = MainWindow(tearOutReceiver: true)
+        try? window.activate()
+        MainWindow.spareReceiver = window
+        return window
+    }
 
-        tabView.tabDragStarting.addHandler { [weak hintBorder] _, _ in
-            hintBorder?.visibility = .visible
-            hintBorder?.opacity = 1
-        }
-        tabView.tabDragCompleted.addHandler { [weak hintBorder] _, _ in
-            hintBorder?.opacity = 0
-            hintBorder?.visibility = .collapsed
-        }
+    // Removes a tab from this window's model (its strip item is reconciled away
+    // by renderSelectedTab); the MainWindowTab object — with its history — lives
+    // on to be adopted elsewhere.
+    func releaseTab(_ tab: MainWindowTab) {
+        guard viewModel != nil else { return }
+        viewModel.detachTab(tab)
+        renderSelectedTab()
+    }
+
+    // Adopts a torn tab into this window's model, building a fresh strip item for
+    // it. `at` is the merge drop position; nil appends (the empty-receiver case).
+    func adoptTornTab(_ tab: MainWindowTab, at index: Int? = nil) {
+        guard viewModel != nil else { return }
+        awaitTransferredTab = false
+        viewModel.adoptTab(tab, at: index, transitionInfoOverride: SuppressNavigationTransitionInfo())
+        renderSelectedTab()
+    }
+
+    // Closes this window once its last tab has been torn/merged away, so an
+    // emptied floating receiver doesn't linger.
+    func closeIfEmpty() {
+        guard viewModel?.tabs.isEmpty ?? false else { return }
+        try? close()
     }
 
     func focusTab(matchingURL url: URL) -> Bool {

--- a/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
@@ -111,6 +111,25 @@ extension MainWindow {
         updateAllTabItemCloseStates()
     }
 
+    // After an in-window drag reorder WinUI has already moved the TabViewItems,
+    // but viewModel.tabs still holds the old order. Rebuild it from the strip so
+    // the reorder survives later add/close operations, which re-sync items to
+    // the model order and would otherwise snap the tabs back.
+    func syncTabOrderFromStrip() {
+        guard let items = tabView.tabItems else { return }
+        var reordered: [MainWindowTab] = []
+        var i: UInt32 = 0
+        while i < items.size {
+            if let item = items.getAt(i) as? TabViewItem, let tab = tab(for: item) {
+                reordered.append(tab)
+            }
+            i += 1
+        }
+        guard reordered.count == viewModel.tabs.count else { return }
+        viewModel.reorder(to: reordered)
+        tabStripIDs = reordered.map { ObjectIdentifier($0) }
+    }
+
     private func tabViewItem(_ item: TabViewItem?, represents id: ObjectIdentifier) -> Bool {
         guard let item else { return false }
         if tabIDByName[item.name] == id {

--- a/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+WindowLifecycle.swift
@@ -19,6 +19,20 @@ extension MainWindow {
         self.closed.addHandler { [weak self] _, _ in
             guard let self else { return }
 
+            // A speculative tear-out can create an empty spare window that never
+            // gets a tab. The process exits only when all windows close, so a
+            // lingering spare keeps it alive after the user closes the real
+            // windows. Drop the empty spare and stale tear state on any close.
+            if MainWindow.spareReceiver === self {
+                MainWindow.spareReceiver = nil
+                MainWindow.pendingTearOut = nil
+            } else if let spare = MainWindow.spareReceiver,
+                      spare.viewModel?.tabs.isEmpty ?? true {
+                MainWindow.spareReceiver = nil
+                MainWindow.pendingTearOut = nil
+                try? spare.close()
+            }
+
             // 先 cancel observation tasks，避免死窗口的 task 继续访问 self.appWindow / self.viewModel
             self.envObservationTask?.cancel()
             self.routeObservationTask?.cancel()
@@ -79,7 +93,6 @@ extension MainWindow {
         titleBar.title = self.title
         searchBox?.placeholderText = MainWindow.tr("searchControlsAndSamples")
         applyCloseOthersTooltip(to: closeOtherTabsButton)
-        tabDragHintText?.text = MainWindow.tr("TabDragHint")
 
         let context = WindowContext(owner: self)
         titleBarRightHeader.children.clear()
@@ -95,6 +108,12 @@ extension MainWindow {
             for item in module.navigationViewFooterMenuItemsRequired(in: context) {
                 appendNavigationItem(item, true)
             }
+        }
+
+        // An empty tear-out receiver: the torn tab is injected later by
+        // tabTearOutRequested, so skip all startup navigation and come up blank.
+        if awaitTransferredTab {
+            return
         }
 
         if let makeInitialPage = initialPageFactory {
@@ -132,6 +151,9 @@ extension MainWindow {
     }
     
     private func restoreWindowRect() {
+        // A tear-out receiver is positioned by the OS as it follows the cursor —
+        // don't restore the saved main-window rect over it.
+        guard !isTearOutWindow else { return }
         guard let hwnd = self.appWindow, let presenter = hwnd.presenter as? OverlappedPresenter
         else { return }
 

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -30,18 +30,28 @@ class MainWindow: Window {
     // When true, launch skips currentPage/lastPageURL restore and selects the
     // first NavigationView item instead.
     var forceHomeOnLaunch: Bool = false
-    static var isTabTearOffMergeEnabled = false
-    var tabDragHintBorder: Border? = nil
-    // 持有提示文本以便语言切换时重设（文本在 setupTabDragHint 创建时定格）
-    var tabDragHintText: TextBlock? = nil
-    var draggingTabForDrop: MainWindowTab? = nil
-    var dragDroppedOutside = false
-
-    struct DragState {
-        let sourceWindowID: ObjectIdentifier
-        let tabURL: URL
+    // An empty window created to receive a tab torn out into a new window. It
+    // comes up with no tab (startup navigation is skipped) and waits for
+    // tabTearOutRequested to inject the torn tab; it also skips position restore.
+    var awaitTransferredTab: Bool = false
+    var isTearOutWindow: Bool = false
+    static var isTabTearOffMergeEnabled = true
+    // Tracks the single tab being torn out across windows. Drag is single-pointer
+    // on the UI thread, so at most one is ever in flight. `holder` follows the tab
+    // as it moves between windows during the drag; `receiver` is the floating
+    // window the native flow asked us to create. The receiver is resolved from
+    // HERE, not from args.newWindowId — that property reads back 0 in the
+    // tabTearOutRequested event, so we remember it ourselves.
+    struct PendingTearOut {
+        let tab: MainWindowTab
+        var holder: MainWindow
+        let receiver: MainWindow
     }
-    static var activeDrag: DragState? = nil
+    static var pendingTearOut: PendingTearOut? = nil
+    // Reused so the framework's repeated windowRequested calls within one drag
+    // (it over-fires, incl. speculative tears it never commits) don't leak empty
+    // windows.
+    static var spareReceiver: MainWindow? = nil
 
     // 持有 Observation Task 句柄，窗口关闭时 cancel，避免死窗口的 task 继续访问失效的 self.appWindow / self.viewModel
     var envObservationTask: Task<Void, Never>?
@@ -207,11 +217,14 @@ class MainWindow: Window {
         tabs.tabStripHeader = closeOtherTabsButton
         tabs.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)
         tabs.margin = Thickness(left: 0, top: -1, right: 0, bottom: 0)
+        // Native tab tear-out: canTearOutTabs hands the drag visuals and the
+        // window-follow animation to the OS; the tear-out event handlers only keep
+        // the model (MainWindowTab + its decoupled content frame) in step by moving
+        // it between windows. This native path supersedes the classic-drag
+        // cross-window merge, so allowDropTabs/allowDrop are not wired here.
         tabs.canDragTabs = true
         tabs.canReorderTabs = true
-        tabs.allowDropTabs = true
-        tabs.canTearOutTabs = false
-        tabs.allowDrop = MainWindow.isTabTearOffMergeEnabled
+        tabs.canTearOutTabs = MainWindow.isTabTearOffMergeEnabled
         return tabs
     } ()
     lazy var tabContentHost = Grid()
@@ -280,6 +293,15 @@ class MainWindow: Window {
     init(forceHomeOnLaunch: Bool) {
         super.init()
         self.forceHomeOnLaunch = forceHomeOnLaunch
+        bootstrap()
+    }
+
+    // Empty receiver window for a tear-out. Comes up with no tab and skips
+    // position restore; the torn tab is injected by tabTearOutRequested.
+    init(tearOutReceiver: Bool) {
+        super.init()
+        self.awaitTransferredTab = tearOutReceiver
+        self.isTearOutWindow = tearOutReceiver
         bootstrap()
     }
 

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -70,8 +70,12 @@ class MainWindowViewModel {
     var selectedTab: MainWindowTab? = nil
     var navigationRevision: Int = 0
 
-    var backwardPages: [Page] = []
-    var forwardPages: [Page] = []
+    var backwardPages: [Page] {
+        selectedTab?.backwardPages ?? []
+    }
+    var forwardPages: [Page] {
+        selectedTab?.forwardPages ?? []
+    }
     var currentPage: Page? {
         selectedTab?.currentPage
     }
@@ -100,7 +104,8 @@ class MainWindowViewModel {
     ) -> MainWindowTab {
         let tab: MainWindowTab
         if inNewTab || selectedTab == nil {
-            tab = addTab(for: page, transitionInfoOverride: transitionInfoOverride)
+            tab = MainWindowTab(page: page, transitionInfoOverride: transitionInfoOverride)
+            tabs.append(tab)
         } else {
             tab = selectedTab!
             tab.navigate(
@@ -110,13 +115,10 @@ class MainWindowViewModel {
             )
         }
 
-        // 后台新 tab（switchToTab == false）保持原选中 tab 不变；
-        // 第一次开 tab（selectedTab 之前为 nil）必须切过去否则没有可显示的 tab。
         if switchToTab || selectedTab == nil {
             selectedTab = tab
             routePreferences.lastPageURL = page.url
         }
-        syncLegacyHistory()
         navigationRevision += 1
         return tab
     }
@@ -126,7 +128,6 @@ class MainWindowViewModel {
 
         selectedTab.goBack(transitionInfoOverride)
         routePreferences.lastPageURL = currentPage?.url
-        syncLegacyHistory()
         navigationRevision += 1
     }
 
@@ -135,7 +136,6 @@ class MainWindowViewModel {
 
         selectedTab.goForward(transitionInfoOverride)
         routePreferences.lastPageURL = currentPage?.url
-        syncLegacyHistory()
         navigationRevision += 1
     }
 
@@ -160,7 +160,6 @@ class MainWindowViewModel {
             selectedTab = tab
             routePreferences.lastPageURL = page.url
         }
-        syncLegacyHistory()
         navigationRevision += 1
         return tab
     }
@@ -169,7 +168,6 @@ class MainWindowViewModel {
         guard tabs.contains(where: { $0 === tab }) else { return }
         selectedTab = tab
         routePreferences.lastPageURL = tab.currentPage?.url
-        syncLegacyHistory()
         navigationRevision += 1
     }
 
@@ -182,14 +180,17 @@ class MainWindowViewModel {
             selectedTab = tabs[min(index, tabs.count - 1)]
             routePreferences.lastPageURL = selectedTab?.currentPage?.url
         }
-        syncLegacyHistory()
         navigationRevision += 1
+    }
+
+    func reorder(to reordered: [MainWindowTab]) {
+        guard reordered.count == tabs.count else { return }
+        tabs = reordered
     }
 
     func closeOtherTabs() {
         guard let tab = selectedTab, tabs.count > 1 else { return }
         tabs = [tab]
-        syncLegacyHistory()
         navigationRevision += 1
     }
 
@@ -202,40 +203,31 @@ class MainWindowViewModel {
             selectedTab = tabs.isEmpty ? nil : tabs[min(index, tabs.count - 1)]
             routePreferences.lastPageURL = selectedTab?.currentPage?.url
         }
-        syncLegacyHistory()
         navigationRevision += 1
     }
 
-    /// Seeds this ViewModel with a tab transferred from another window.
-    func setTransferredTab(_ tab: MainWindowTab) {
+    /// Adopts an existing tab object dragged in from another window (merge),
+    /// preserving its back/forward history instead of re-navigating by URL.
+    @discardableResult
+    func adoptTab(
+        _ tab: MainWindowTab,
+        at index: Int? = nil,
+        transitionInfoOverride: NavigationTransitionInfo? = nil,
+        switchToTab: Bool = true
+    ) -> MainWindowTab {
+        guard !tabs.contains(where: { $0 === tab }) else { return tab }
+        tab.navigationTransitionInfo = transitionInfoOverride
         tab.needsRender = true
-        tabs = [tab]
-        selectedTab = tab
-        routePreferences.lastPageURL = tab.currentPage?.url
-        syncLegacyHistory()
+        if let index, index >= 0, index <= tabs.count {
+            tabs.insert(tab, at: index)
+        } else {
+            tabs.append(tab)
+        }
+        if switchToTab || selectedTab == nil {
+            selectedTab = tab
+            routePreferences.lastPageURL = tab.currentPage?.url
+        }
         navigationRevision += 1
-    }
-
-    func dumpHistory() {
-        for (index, page) in (selectedTab?.backwardPages ?? []).enumerated() {
-            log.info("\(index) <===\(page.url)")
-        }
-        log.info("-----------------------------------------------")
-        log.info("====\(currentPage?.url.absoluteString ?? "nil")")
-        log.info("-----------------------------------------------")
-        for (index, page) in (selectedTab?.forwardPages ?? []).enumerated() {
-            log.info("\(index) ===>\(page.url)")
-        }
-    }
-
-    private func addTab(for page: Page, transitionInfoOverride: NavigationTransitionInfo?) -> MainWindowTab {
-        let tab = MainWindowTab(page: page, transitionInfoOverride: transitionInfoOverride)
-        tabs.append(tab)
         return tab
-    }
-
-    private func syncLegacyHistory() {
-        backwardPages = selectedTab?.backwardPages ?? []
-        forwardPages = selectedTab?.forwardPages ?? []
     }
 }


### PR DESCRIPTION
# feat(tabs): native tab tear-out and merge

## Overview

将tabview的 tearout 和 drop 行为从 OLE 实现方式改为 WinUI Native 方式，开启 canTearOutTabs=true，绑定其需要的事件，移除OLE绑定事件，Native绑定的事件如下：

- tabTearOutWindowRequested
- tabTearOutRequested
- externalTornOutTabsDropping
- externalTornOutTabsDropped