### PR TITLE
fix(tabs): rebind page WindowContext on tab tear-out and merge

### DIFF
--- a/Samples/SampleApp/ArbitraryModule/Pages/AppearancePage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/AppearancePage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class AppearancePage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Samples/SampleApp/ArbitraryModule/Pages/FolderPickerPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/FolderPickerPage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class FolderPickerPage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Samples/SampleApp/ArbitraryModule/Pages/FullscreenPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/FullscreenPage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class FullscreenPage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Samples/SampleApp/ArbitraryModule/Pages/NavigationModesPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/NavigationModesPage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class NavigationModesPage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Samples/SampleApp/ArbitraryModule/Pages/NewWindowPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/NewWindowPage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class NewWindowPage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Samples/SampleApp/ArbitraryModule/Pages/OpenOrFocusPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/OpenOrFocusPage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class OpenOrFocusPage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Samples/SampleApp/ArbitraryModule/Pages/OverviewPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/OverviewPage.swift
@@ -4,9 +4,13 @@ import WinUI
 import RsUI
 
 final class OverviewPage: RsUI.Page {
-    let context: WindowContext
+    var context: WindowContext
 
     init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
         self.context = context
     }
 

--- a/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+TabInteraction.swift
@@ -81,6 +81,12 @@ extension MainWindow {
     func adoptTornTab(_ tab: MainWindowTab, at index: Int? = nil) {
         guard viewModel != nil else { return }
         awaitTransferredTab = false
+        // The same Page instances travel with the tab; rebind their context to
+        // this window so window-scoped calls hit the new owner, not the creator.
+        let context = WindowContext(owner: self)
+        for page in tab.allPages {
+            page.windowContextChanged(context)
+        }
         viewModel.adoptTab(tab, at: index, transitionInfoOverride: SuppressNavigationTransitionInfo())
         renderSelectedTab()
     }

--- a/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindowViewModel.swift
@@ -10,6 +10,12 @@ class MainWindowTab {
     var navigationTransitionInfo: NavigationTransitionInfo? = nil
     var needsRender: Bool = false
 
+    // Current page plus both history stacks, e.g. to rebind page-held state when
+    // the tab migrates to another window.
+    var allPages: [Page] {
+        backwardPages + forwardPages + (currentPage.map { [$0] } ?? [])
+    }
+
     init(page: Page, transitionInfoOverride: NavigationTransitionInfo? = nil) {
         navigate(to: page, transitionInfoOverride: transitionInfoOverride)
     }

--- a/Sources/RsUI/Models/Page.swift
+++ b/Sources/RsUI/Models/Page.swift
@@ -7,10 +7,17 @@ public protocol Page: AnyObject {
     var header: Any? { get }
     var title: String { get }
     var content: UIElement { get }
+
+    // Called when the page's tab is moved to another window (tab tear-out or
+    // merge). A page that caches window-scoped state from its WindowContext
+    // should rebind it here, else calls like fullscreen act on the old window.
+    func windowContextChanged(_ context: WindowContext)
 }
 
 public extension Page {
     var header: Any? { nil }
+
+    func windowContextChanged(_ context: WindowContext) {}
 
     func startObserving<Element>(_ emit: @escaping @Sendable () -> Element, onChanged: @escaping @MainActor (Page, Element) -> Void) {
         let obs = Observations(emit)


### PR DESCRIPTION
## 问题

标签页拖出或合并时会迁移同一个 Page 实例，但 Page 初始化时收到的 WindowContext 不会随所属窗口更新。因此拖出的标签页在这里调用全屏，会错误地操作。原窗口当前选中的标签页。RsUI 需要在标签迁移后更新 Page 的窗口上下文，或提供一个能根据当前 Page/Tab 解析所属窗口并执行全屏的公开 API。


## 方案

- Page 协议新增 `windowContextChanged(_:)`
- tab 迁入新窗口时(`adoptTornTab`）， 给 tab 内所有 Page(当前页 + 前后历史栈)更新窗口的 WindowContext。

## 改动

- `Page.swift`：`windowContextChanged` 协议要求 + 空默认实现
- `MainWindowViewModel.swift`：增加计算属性`MainWindowTab.allPages`
- `MainWindow+TabInteraction.swift`：`adoptTornTab` 中 rebind