### PR TITLE
Disable native tab tear-out

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Content.swift
@@ -67,11 +67,32 @@ extension MainWindow {
             self?.openNewTabFromTabStrip()
         }
 
-        guard MainWindow.isTabTearOffMergeEnabled else { return }
+        // Persist an in-window reorder. Native tear-out suppresses
+        // tabDragCompleted, but a drag-reorder still mutates the TabItems
+        // collection directly, so tabItemsChanged is the only hook that sees it.
+        // A real tear-out also mutates the collection, but then a tab has LEFT
+        // this strip, so syncTabOrderFromStrip's count check bails: the strip
+        // must still hold exactly our model's tabs. That is what separates a
+        // reorder from a tear-out, not the tear flag. Skip only our own
+        // syncTabItems edits (isSyncingTabSelection); tabStripIDs stops the
+        // follow-up sync from looping.
+        tabView.tabItemsChanged.addHandler { [weak self] _, _ in
+            guard let self, !self.isSyncingTabSelection else { return }
+            self.syncTabOrderFromStrip()
+        }
+
+        configureTabTearOutEvents()
+    }
+
+    // Registers native tear-out/merge handlers. the guard below gates this 
+    // optional native tear-out/merge.
+    private func configureTabTearOutEvents() {
+        guard MainWindow.tabTearOutEnabled else { return }
 
         // Native tear-out (CanTearOutTabs). The OS owns the drag visuals and the
-        // window-follow animation; these handlers only move our model — the
+        // window-follow animation; these handlers only move our model — the 
         // MainWindowTab plus its decoupled content frame — between windows.
+
         // Both the tab in flight and its receiving window are tracked in
         // MainWindow.pendingTearOut. The receiver can't be read from the event:
         // tabTearOutRequested gives args.newWindowId 0 even though we set it in
@@ -81,7 +102,9 @@ extension MainWindow {
         // A tab is being torn out and needs a window to land in. The framework
         // over-fires this within one drag (incl. speculative tears it never
         // commits), so tearOutReceiver() reuses one empty spare instead of
-        // leaking a window per call.
+        // leaking a window per call. Without reuse, speculative requests can
+        // leave empty receiver windows that never get a tab and keep the app
+        // process alive after the real windows close.
         tabView.tabTearOutWindowRequested.addHandler { [weak self] _, args in
             guard let self, let args else { return }
             // WinUI selects the pressed tab before the tear begins, so the
@@ -106,7 +129,8 @@ extension MainWindow {
             MainWindow.spareReceiver = nil
         }
 
-        // A torn tab from another window is dragged over this strip — accept.
+        // A torn tab from another window is dragged over this strip. always 
+        // allow it to drop.
         tabView.externalTornOutTabsDropping.addHandler { _, args in
             guard let args, MainWindow.pendingTearOut != nil else { return }
             args.allowDrop = true
@@ -127,20 +151,6 @@ extension MainWindow {
                 Task { @MainActor in receiver.closeIfEmpty() }
             }
             MainWindow.pendingTearOut = nil
-        }
-
-        // Persist an in-window reorder. Native tear-out suppresses
-        // tabDragCompleted, but a drag-reorder still mutates the TabItems
-        // collection directly, so tabItemsChanged is the only hook that sees it.
-        // A real tear-out also mutates the collection, but then a tab has LEFT
-        // this strip, so syncTabOrderFromStrip's count check bails: the strip
-        // must still hold exactly our model's tabs. That is what separates a
-        // reorder from a tear-out, not the tear flag. Skip only our own
-        // syncTabItems edits (isSyncingTabSelection); tabStripIDs stops the
-        // follow-up sync from looping.
-        tabView.tabItemsChanged.addHandler { [weak self] _, _ in
-            guard let self, !self.isSyncingTabSelection else { return }
-            self.syncTabOrderFromStrip()
         }
     }
 

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -35,13 +35,25 @@ class MainWindow: Window {
     // tabTearOutRequested to inject the torn tab; it also skips position restore.
     var awaitTransferredTab: Bool = false
     var isTearOutWindow: Bool = false
-    static var isTabTearOffMergeEnabled = true
+
+    // Keep native TabView tear-out disabled for now. CanTearOutTabs currently
+    // has two blocking issues for this shell:
+    // - TabTearOutWindowRequested can make the receiver window visible briefly,
+    //   causing flicker and taskbar animation.
+    //   https://github.com/microsoft/microsoft-ui-xaml/issues/10155
+    // - With a custom title bar, switching tabs can corrupt the drag region so
+    //   dragging the title bar tears out a tab instead of moving the window.
+    //   https://github.com/microsoft/microsoft-ui-xaml/issues/11170
+    // Keep the tear-out handlers behind this same gate so the native path can
+    // be restored when the WinUI behavior is fixed.
+    static let tabTearOutEnabled = false
+    
     // Tracks the single tab being torn out across windows. Drag is single-pointer
     // on the UI thread, so at most one is ever in flight. `holder` follows the tab
     // as it moves between windows during the drag; `receiver` is the floating
-    // window the native flow asked us to create. The receiver is resolved from
-    // HERE, not from args.newWindowId — that property reads back 0 in the
-    // tabTearOutRequested event, so we remember it ourselves.
+    // window the native flow asked us to create. 
+    // The receiver is resolved from HERE, not from args.newWindowId — that property 
+    // reads back 0 in the tabTearOutRequested event, so we remember it ourselves.
     struct PendingTearOut {
         let tab: MainWindowTab
         var holder: MainWindow
@@ -217,14 +229,11 @@ class MainWindow: Window {
         tabs.tabStripHeader = closeOtherTabsButton
         tabs.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)
         tabs.margin = Thickness(left: 0, top: -1, right: 0, bottom: 0)
-        // Native tab tear-out: canTearOutTabs hands the drag visuals and the
-        // window-follow animation to the OS; the tear-out event handlers only keep
-        // the model (MainWindowTab + its decoupled content frame) in step by moving
-        // it between windows. This native path supersedes the classic-drag
-        // cross-window merge, so allowDropTabs/allowDrop are not wired here.
         tabs.canDragTabs = true
         tabs.canReorderTabs = true
-        tabs.canTearOutTabs = MainWindow.isTabTearOffMergeEnabled
+        // Mirrors tabTearOutEnabled; see the flag comment for why native
+        // tear-out is currently off.
+        tabs.canTearOutTabs = MainWindow.tabTearOutEnabled
         return tabs
     } ()
     lazy var tabContentHost = Grid()


### PR DESCRIPTION
Disable native WinUI tab tear-out

Keep native TabView tear-out disabled for now. CanTearOutTabs currentlyhas two blocking issues:

- TabTearOutWindowRequested can make the receiver window visible briefly, causing flicker and taskbar animation.
- With a custom title bar, switching tabs can corrupt the drag region so dragging the title bar tears out a tab instead of moving the window.

Keep the tear-out handlers behind this same gate so the native path can be restored when the WinUI behavior is fixed.