### PR TITLE
feat(tabs): add batch tab opening APIs

### DIFF
--- a/Samples/SampleApp/ArbitraryModule/ArbitaryModule.swift
+++ b/Samples/SampleApp/ArbitraryModule/ArbitaryModule.swift
@@ -48,6 +48,7 @@ final class ArbitaryModule: Module {
             NavigationViewItem.build(iconGlyph: "\u{E740}", label: tr("Tab Fullscreen"), url: "rs://\(id)/fullscreen"),
             NavigationViewItem.build(iconGlyph: "\u{ECCD}", label: tr("Navigation Modes"), url: "rs://\(id)/navigation"),
             NavigationViewItem.build(iconGlyph: "\u{E8A7}", label: tr("Open or Focus"), url: "rs://\(id)/openorfocus"),
+            NavigationViewItem.build(iconGlyph: "\u{E8FD}", label: tr("Batch Open"), url: "rs://\(id)/batch-open"),
             NavigationViewItem.build(iconGlyph: "\u{E78B}", label: tr("New Window"), url: "rs://\(id)/new-window"),
             NavigationViewItem.build(iconGlyph: "\u{E771}", label: tr("Appearance"), url: "rs://\(id)/appearance"),
             NavigationViewItem.build(iconGlyph: "\u{E8B7}", label: tr("Folder Picker"), url: "rs://\(id)/folder-picker"),
@@ -126,6 +127,8 @@ final class ArbitaryModule: Module {
             return NavigationModesPage(context: context)
         case "/openorfocus":
             return OpenOrFocusPage(context: context)
+        case "/batch-open":
+            return BatchOpenPage(context: context)
         case "/new-window":
             return NewWindowPage(context: context)
         case "/appearance":

--- a/Samples/SampleApp/ArbitraryModule/Pages/BatchOpenPage.swift
+++ b/Samples/SampleApp/ArbitraryModule/Pages/BatchOpenPage.swift
@@ -1,0 +1,73 @@
+import Foundation
+import UWP
+import WinUI
+import RsUI
+
+final class BatchOpenPage: RsUI.Page {
+    var context: WindowContext
+
+    init(context: WindowContext) {
+        self.context = context
+    }
+
+    func windowContextChanged(_ context: WindowContext) {
+        self.context = context
+    }
+
+    var url: URL { URL(string: "rs://arbitrary/batch-open")! }
+    var title: String { tr("Batch Open") }
+
+    // The routes opened by the batch demo, in tab order.
+    private var routes: [URL] {
+        [
+            "rs://arbitrary/navigation",
+            "rs://arbitrary/openorfocus",
+            "rs://arbitrary/appearance",
+            "rs://arbitrary/fullscreen",
+        ].compactMap { URL(string: $0) }
+    }
+
+    var header: Any? {
+        featurePageHeader(
+            title: tr("Batch Open"),
+            description: tr("context.open([URL]) opens many tabs in one render instead of looping over open(_:mode:).")
+        )
+    }
+
+    var content: WinUI.UIElement {
+        let cards: [UIElement] = [
+            makeCard(
+                glyph: "\u{ECCD}",
+                header: tr("Open all in foreground"),
+                description: tr("context.open(routes) — opens every route as a tab and selects the last one."),
+                mode: .newTab
+            ),
+            makeCard(
+                glyph: "\u{F22C}",
+                header: tr("Open all in background"),
+                description: tr("context.open(routes, mode: .newTabBackground) — opens the same tabs without leaving this page."),
+                mode: .newTabBackground
+            ),
+        ]
+        return featurePageContent(cards)
+    }
+
+    private func makeCard(
+        glyph: String,
+        header: String,
+        description: String,
+        mode: NavigationOpenMode
+    ) -> SettingsCard {
+        let card = SettingsCard(
+            headerIconGlyph: glyph,
+            header: header,
+            description: description
+        )
+        card.isClickEnabled = true
+        card.click.addHandler { [weak self] _, _ in
+            guard let self else { return }
+            _ = self.context.open(self.routes, mode: mode)
+        }
+        return card
+    }
+}

--- a/Sources/RsUI/App/MainWindow/MainWindow+Navigation.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Navigation.swift
@@ -96,21 +96,27 @@ extension MainWindow {
             return true
         }
 
+        guard let page = resolvePage(for: url) else { return false }
+        performNavigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
+        return true
+    }
+
+    // Resolves a route URL to a Page via Settings or a registered module, without
+    // performing any navigation. Returns nil when no module claims the URL. The
+    // batch tab APIs reuse this so a list of URLs can be turned into pages up front.
+    func resolvePage(for url: URL) -> Page? {
         if url == SettingsPage.url {
-            performNavigate(to: SettingsPage(), mode: mode, transitionInfoOverride: transitionInfoOverride)
-            return true
-        } else {
-            let context = WindowContext(owner: self)
-            for module in App.context.modules {
-                if let page = module.navigationRequested(for: url, in: context) {
-                    performNavigate(to: page, mode: mode, transitionInfoOverride: transitionInfoOverride)
-                    return true
-                }
+            return SettingsPage()
+        }
+        let context = WindowContext(owner: self)
+        for module in App.context.modules {
+            if let page = module.navigationRequested(for: url, in: context) {
+                return page
             }
         }
-        return false
+        return nil
     }
- 
+
 
     func firstNavigationItemURL() -> URL? {
         return firstNavigationItemURL(in: navigationView.menuItems)

--- a/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
@@ -157,6 +157,51 @@ extension MainWindow {
         return ctx
     }
 
+    // Batch form of addTab: inserts every page as a tab but renders the strip
+    // only once at the end, instead of once per tab. A client loop that called
+    // addTab N times would pay renderSelectedTab() N times — and its
+    // O(tabCount) closable-state rescan makes that O(N²) — plus N selection
+    // changes and N frame shows. Here all items are inserted first, the final
+    // selection is chosen once, and a single renderSelectedTab() draws only the
+    // landed tab; background tabs stay unrendered until first selected, exactly
+    // like a single background addTab.
+    @discardableResult
+    func addTabs(
+        pages: [Page],
+        switchToLast: Bool = true,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> [TabContext] {
+        guard !pages.isEmpty else { return [] }
+        let hadSelection = selectedTabContext != nil
+
+        var contexts: [TabContext] = []
+        contexts.reserveCapacity(pages.count)
+        for page in pages {
+            let model = MainWindowTab(page: page, transitionInfoOverride: transitionInfoOverride)
+            let ctx = makeTab(model: model)
+            insertItem(ctx.item, at: nil)
+            contexts.append(ctx)
+        }
+
+        // Mirror the looped-addTab selection: foreground lands on the last tab;
+        // a background batch into an empty window still needs a selection, so it
+        // lands on the first; an existing selection is otherwise preserved.
+        let selection: TabContext?
+        if switchToLast {
+            selection = contexts.last
+        } else if !hadSelection {
+            selection = contexts.first
+        } else {
+            selection = nil
+        }
+        if let selection {
+            selectItem(selection.item)
+        }
+
+        renderSelectedTab()
+        return contexts
+    }
+
     // Removes a tab from the strip and tears down its frame, keeping its model
     // alive so a tear-out/detach caller can re-home it. Does not adjust selection.
     func removeTab(_ ctx: TabContext) {

--- a/Sources/RsUI/Models/WindowContext.swift
+++ b/Sources/RsUI/Models/WindowContext.swift
@@ -123,6 +123,86 @@ public struct WindowContext {
         return owner?.navigate(to: url, mode: mode, transitionInfoOverride: transitionInfoOverride) ?? false
     }
 
+    /// Opens several pages as tabs in one batch.
+    ///
+    /// Use this instead of calling `open(_:mode:)` in a loop: every page is
+    /// inserted first and the tab strip is rendered a single time, so opening
+    /// N tabs costs one render instead of N. There is no need to hop onto a
+    /// `Task` to add tabs one by one.
+    ///
+    /// - Parameters:
+    ///   - pages: The page instances to open, in tab order. An empty array is a
+    ///     no-op. Each page is a separate tab; pass pre-built `Page` instances
+    ///     bound to this window's context.
+    ///   - mode: Controls selection only. `.newTab` (default) selects the last
+    ///     opened tab; `.newTabBackground` keeps the current selection (or lands
+    ///     on the first new tab if the window was empty). `.inplace` and
+    ///     `.newWindow` are not batch modes and behave like `.newTab`.
+    ///   - transitionInfoOverride: Optional WinUI navigation transition applied
+    ///     when each tab first renders.
+    /// - Returns: The number of tabs opened (equal to `pages.count`).
+    ///
+    /// Example:
+    /// ```swift
+    /// context.open([DetailsPage(id: 1), DetailsPage(id: 2), DetailsPage(id: 3)])
+    /// ```
+    @discardableResult
+    public func open(
+        _ pages: [Page],
+        mode: NavigationOpenMode = .newTab,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Int {
+        guard let owner else { return 0 }
+        let contexts = owner.addTabs(
+            pages: pages,
+            switchToLast: mode != .newTabBackground,
+            transitionInfoOverride: transitionInfoOverride
+        )
+        return contexts.count
+    }
+
+    /// Opens several URLs as tabs in one batch.
+    ///
+    /// Each URL is resolved through Settings or a module's
+    /// `navigationRequested(for:in:)`, then all resolved pages are opened with a
+    /// single tab-strip render — the URL counterpart to `open(_:mode:)` for
+    /// arrays. URLs that no module claims are skipped.
+    ///
+    /// - Parameters:
+    ///   - urls: The route URLs to resolve and open, in tab order. An empty
+    ///     array is a no-op.
+    ///   - mode: Controls selection only, identical to the `[Page]` overload:
+    ///     `.newTab` (default) selects the last opened tab, `.newTabBackground`
+    ///     keeps the current selection. `.inplace` and `.newWindow` behave like
+    ///     `.newTab`.
+    ///   - transitionInfoOverride: Optional WinUI navigation transition applied
+    ///     when each tab first renders.
+    /// - Returns: The number of tabs opened — i.e. how many URLs resolved to a
+    ///   page. May be fewer than `urls.count` if some were unrouted.
+    ///
+    /// Example:
+    /// ```swift
+    /// _ = context.open([
+    ///     URL(string: "rs://arbitrary/navigation")!,
+    ///     URL(string: "rs://arbitrary/openorfocus")!,
+    /// ])
+    /// ```
+    @discardableResult
+    public func open(
+        _ urls: [URL],
+        mode: NavigationOpenMode = .newTab,
+        transitionInfoOverride: NavigationTransitionInfo? = nil
+    ) -> Int {
+        guard let owner else { return 0 }
+        let pages = urls.compactMap { owner.resolvePage(for: $0) }
+        let contexts = owner.addTabs(
+            pages: pages,
+            switchToLast: mode != .newTabBackground,
+            transitionInfoOverride: transitionInfoOverride
+        )
+        return contexts.count
+    }
+
     /// Builds a page with the destination window context and opens it with the requested mode.
     ///
     /// Use this overload when the page should receive a `WindowContext` at construction


### PR DESCRIPTION
## Changes

- 为 WindowContext.open 增加批量打开 [Page] 和 [URL] 的重载(.newTab：打开全部标签页并选中最后一个, .newTabBackground：打开全部标签页并保持当前选择)
- 新增 MainWindow.addTabs，批量插入标签后只渲染一次
- 在 SampleApp 中增加前台和后台批量打开标签页的展示页面