### PR TITLE
fix(tabs): size tabs to content with a minimum width

### DIFF
--- a/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow+Tabs.swift
@@ -129,6 +129,7 @@ extension MainWindow {
     func makeTab(model: MainWindowTab) -> TabContext {
         let item = TabViewItem()
         item.name = UUID().uuidString
+        item.minWidth = 100
 
         let frame = PageTransitionHost()
         frame.visibility = .collapsed

--- a/Sources/RsUI/App/MainWindow/MainWindow.swift
+++ b/Sources/RsUI/App/MainWindow/MainWindow.swift
@@ -219,7 +219,7 @@ class MainWindow: Window {
     lazy var tabView: TabView = {
         let tabs = TabView()
         tabs.isAddTabButtonVisible = true
-        tabs.tabWidthMode = .equal
+        tabs.tabWidthMode = .sizeToContent
         tabs.closeButtonOverlayMode = .onPointerOver
         tabs.tabStripHeader = closeOtherTabsButton
         tabs.padding = Thickness(left: 0, top: 0, right: 0, bottom: 0)


### PR DESCRIPTION
## Changes

- tabView.tabWidthMode：.equal → .sizeToContent，winui3内置 tabview item 宽度模式的改变，改为适应内容长度。
- TabViewItem 处设置 minWidth = 100


## TabViewItem 在 equal 模式下宽度不一致的原因

Equal模式的原理是每当有标签变化，根据现在可以展示的宽度和标签数量计算出新的每个标签的数量。并设置给每一个TabViewItem的Width属性。

虽然Width 属性的设置是同步完成的，但界面上实际显示的 ActualWidth 只有在下一次 XAML measure/arrange 布局完成后才会更新。如果多次创建复杂页面。该页面初始化延迟了下一次完整布局，从而暴露了一个中间状态：

- 已存在的标签仍显示上一次布局得到的较大宽度；
- 新创建的标签可能已经按照新的标签数量使用较小宽度；
- 等到下一次完整布局执行后，所有标签才会收敛到相同宽度。

因此出现了“前面打开的标签较宽，后面打开的标签较窄”的现象。

### 解决方法

现在 TabView 使用 TabWidthMode.sizeToContent。

在该模式下，每个标签会根据自己的标题内容独立测量宽度，不再根据标签总数计算和更新一个全局共享宽度。